### PR TITLE
[Bug Fix] Use correct aws-cli param types

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ executors:
 
 orbs:
   aws-cli: circleci/aws-cli@0.1.4
-  aws-ecs: circleci/aws-ecs@dev:develop-16f31180e9c9612d7019181ae89ddbdaa01979a2
+  aws-ecs: circleci/aws-ecs@dev:volatile
   circleci-cli: circleci/circleci-cli@0.1.2
   queue: eddiewebb/queue@1.0.110
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -352,8 +352,8 @@ workflows:
           docker-image-for-job: circleci/python:2.7.15
           requires:
             - ec2_test-update-service-command
-          aws-access-key-id: AWS_ACCESS_KEY_ID
-          aws-region: AWS_DEFAULT_REGION
+          aws-access-key-id: "${AWS_ACCESS_KEY_ID}
+          aws-region: "${AWS_DEFAULT_REGION}"
           family: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
           cluster-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
           container-env-var-updates: "container=${AWS_RESOURCE_NAME_PREFIX_EC2}-service,name=VERSION_INFO,value=\"${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}\",container=${AWS_RESOURCE_NAME_PREFIX_EC2}-service,name=BUILD_DATE,value=$(date)"
@@ -369,8 +369,8 @@ workflows:
           docker-image-for-job: circleci/python:3.4.9
           requires:
             - fargate_test-update-service-command
-          aws-access-key-id: AWS_ACCESS_KEY_ID
-          aws-region: AWS_DEFAULT_REGION
+          aws-access-key-id: "${AWS_ACCESS_KEY_ID}"
+          aws-region: "${AWS_DEFAULT_REGION}"
           family: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
           cluster-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
           container-env-var-updates: "container=${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service,name=VERSION_INFO,value=\"${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}\",container=${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service,name=BUILD_DATE,value=$(date)"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -352,7 +352,7 @@ workflows:
           docker-image-for-job: circleci/python:2.7.15
           requires:
             - ec2_test-update-service-command
-          aws-access-key-id: "${AWS_ACCESS_KEY_ID}
+          aws-access-key-id: "${AWS_ACCESS_KEY_ID}"
           aws-region: "${AWS_DEFAULT_REGION}"
           family: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
           cluster-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -257,6 +257,7 @@ jobs:
           condition: <<parameters.to-prod>>
           steps:
             - run: circleci orb publish <<parameters.filepath>> circleci/aws-ecs@dev:$CIRCLE_BRANCH-$CIRCLE_SHA1 --token $CIRCLE_TOKEN
+            - run: circleci orb publish <<parameters.filepath>> circleci/aws-ecs@dev:volatile --token $CIRCLE_TOKEN
       - when:
           condition: <<parameters.to-prod>>
           steps:

--- a/README.MD
+++ b/README.MD
@@ -26,9 +26,9 @@ You can reference the following Jobs provided by this orb from a 2.1 Workflows c
 | Parameter         | type    | default  |     description |
 |------------------|--------|-------------|----------------|
 | docker-image-for-job        | string  | "circleci/python:3.7.1"    | The docker image to be used for running this job on CircleCI |
-| aws-access-key-id        | env_var_name  | AWS_ACCESS_KEY_ID     | AWS access key id for IAM role. Set this to the name of the environment variable you will set to hold this value, i.e. AWS_ACCESS_KEY. |
-| aws-secret-access-key        | env_var_name  | AWS_SECRET_ACCESS_KEY    | AWS secret key for IAM role. Set this to the name of the environment variable you will set to hold this value, i.e. AWS_SECRET_ACCESS_KEY. |
-| aws-region        | env_var_name  | AWS_REGION    | AWS region to operate in. Defaulted to the value of AWS_REGION |
+| aws-access-key-id        | string  | $AWS_ACCESS_KEY_ID     | AWS access key id for IAM role. Defaulted to $AWS_ACCESS_KEY. |
+| aws-secret-access-key        | string  | $AWS_SECRET_ACCESS_KEY    | AWS secret key for IAM role. Defaulted to $AWS_SECRET_ACCESS_KEY. |
+| aws-region        | string  | $AWS_REGION    | AWS region to operate in. Defaulted to $AWS_REGION. |
 | family        | string  |     | Name of the task definition's family |
 | cluster-name   | string  |   | The short name or full ARN of the cluster that hosts the service |
 | container-image-name-updates      | string   | ""    | Use this to update the Docker image names and/or tag names of existing containers that had been defined in the previous task definition. <br>**Expected format**: container=\<container-name\>,image-and-tag=\<image-name\>:\<tag-name\>\|image=\<image-name\>\|tag=\<tag-name\>,container=...,image-and-tag\|image\|tag=... <br>For each container, specify only either `image-and-tag` or `image` or `tag`.<br>If `image-and-tag` is specified, the container image will be updated to the value of the name-value pair.<br>If `image` is specified, the image tag defined in the previous task definition will be retained, if exists.<br>If `tag` is specified, the image name defined in the previous task definition will be used. |
@@ -44,14 +44,14 @@ You can reference the following Jobs provided by this orb from a 2.1 Workflows c
 version: 2.1
 orbs:
   aws-ecr: circleci/aws-ecr@0.0.4
-  aws-ecs: circleci/aws-ecs@0.0.1
+  aws-ecs: circleci/aws-ecs@0.0.3
 workflows:
   build-and-deploy:
     jobs:
       - aws-ecr/build_and_push_image:
           account-url: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com"
           repo: "${MY_APP_PREFIX}"
-          region: ${AWS_REGION}
+          region: "${AWS_REGION}"
           tag: "${CIRCLE_SHA1}"
       - aws-ecs/deploy-service-update:
           requires:
@@ -96,7 +96,7 @@ version: 2.1
 
 orbs:
   aws-cli: circleci/aws-cli@0.1.4
-  aws-ecs: circleci/aws-ecs@0.0.1
+  aws-ecs: circleci/aws-ecs@0.0.3
 
 jobs:
   update-tag:
@@ -106,7 +106,7 @@ jobs:
       - aws-cli/install
       - aws-cli/configure:
           aws-access-key-id: "$AWS_ACCESS_KEY_ID"
-          region: "$AWS_REGION"
+          aws-region: "$AWS_REGION"
       - aws-ecs/update-service:
           family: "${MY_APP_PREFIX}-service"
           cluster-name: "${MY_APP_PREFIX}-cluster"
@@ -141,7 +141,7 @@ workflows:
 version: 2.1
 orbs:
   aws-cli: circleci/aws-cli@0.1.4
-  aws-ecs: circleci/aws-ecs0.0.1
+  aws-ecs: circleci/aws-ecs@0.0.3
 
 jobs:
   verify-deployment:
@@ -151,7 +151,7 @@ jobs:
       - aws-cli/install
       - aws-cli/configure:
           aws-access-key-id: "$AWS_ACCESS_KEY_ID"
-          region: "$AWS_REGION"
+          aws-region: "$AWS_REGION"
       - run:
           name: Get last task definition
           command: |

--- a/src/orb.yml.hbs
+++ b/src/orb.yml.hbs
@@ -13,7 +13,7 @@ examples:
 
       orbs:
         aws-ecr: circleci/aws-ecr@0.0.4
-        aws-ecs: circleci/aws-ecs@0.0.1
+        aws-ecs: circleci/aws-ecs@0.0.3
 
       workflows:
         build-and-deploy:
@@ -21,7 +21,7 @@ examples:
             - aws-ecr/build_and_push_image:
                 account-url: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com"
                 repo: "${MY_APP_PREFIX}"
-                region: ${AWS_REGION}
+                region: "${AWS_REGION}"
                 tag: "${CIRCLE_SHA1}"
             - aws-ecs/deploy-service-update:
                 requires:
@@ -37,7 +37,7 @@ examples:
 
       orbs:
         aws-cli: circleci/aws-cli@0.1.4
-        aws-ecs: circleci/aws-ecs@0.0.1
+        aws-ecs: circleci/aws-ecs@0.0.3
 
       jobs:
         update-tag:
@@ -47,7 +47,7 @@ examples:
             - aws-cli/install
             - aws-cli/configure:
                 aws-access-key-id: "$AWS_ACCESS_KEY_ID"
-                region: "$AWS_REGION"
+                aws-region: "$AWS_REGION"
             - aws-ecs/update-service:
                 family: "${MY_APP_PREFIX}-service"
                 cluster-name: "${MY_APP_PREFIX}-cluster"
@@ -65,7 +65,7 @@ examples:
 
       orbs:
         aws-cli: circleci/aws-cli@0.1.4
-        aws-ecs: circleci/aws-ecs@0.0.1
+        aws-ecs: circleci/aws-ecs@0.0.3
 
       jobs:
         verify-deployment:
@@ -75,7 +75,7 @@ examples:
             - aws-cli/install
             - aws-cli/configure:
                 aws-access-key-id: "$AWS_ACCESS_KEY_ID"
-                region: "$AWS_REGION"
+                aws-region: "$AWS_REGION"
             - run:
                 name: Get last task definition
                 command: |
@@ -106,23 +106,19 @@ jobs:
         default: circleci/python:3.7.1
       aws-access-key-id:
         description: |
-          AWS access key id for IAM role. Set this to the name of
-          the environment variable you will set to hold this
-          value, i.e. AWS_ACCESS_KEY.
-        type: env_var_name
-        default: AWS_ACCESS_KEY_ID
+          AWS access key id for IAM role. Defaulted to $AWS_ACCESS_KEY_ID
+        type: string
+        default: $AWS_ACCESS_KEY_ID
       aws-secret-access-key:
         description: |
-          AWS secret key for IAM role. Set this to the name of
-          the environment variable you will set to hold this
-          value, i.e. AWS_SECRET_ACCESS_KEY.
-        type: env_var_name
-        default: AWS_SECRET_ACCESS_KEY
+          AWS secret key for IAM role. Defaulted to $AWS_SECRET_ACCESS_KEY
+        type: string
+        default: $AWS_SECRET_ACCESS_KEY
       aws-region:
         description:
-          "Name of environment variable for AWS region to operate in. Defaulted to AWS_REGION"
-        type: env_var_name
-        default: AWS_REGION
+          AWS region to operate in. Defaulted to $AWS_REGION
+        type: string
+        default: $AWS_REGION
       family:
         description:
           "Name of the task definition's family."


### PR DESCRIPTION
- Make the build always test against dev:volatile
- Orb bug fix: Incorrect params are passed to aws-cli orb. aws-cli@0.1.4 orb actually expects the values of the aws-access-key-id, aws-secret-access-key and aws-region parameters to be actual values and not env vars. It seems the bug doesn't surface when AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY and AWS_DEFAULT_REGION are defined as project environment variables, because the actual aws cli (not the orb) is able to read those values and configure itself.

This bug affects aws-ecs@0.0.1 and 0.0.2 and can be reproduced with the below config:

```
version: 2.1
orbs:
  aws-ecr: circleci/aws-ecr@0.0.4
  aws-ecs: circleci/aws-ecs@0.0.2
workflows:
  build-and-deploy:
    jobs:
      - aws-ecr/build_and_push_image:
          account-url: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com"
          repo: "${AWS_RESOURCE_NAME_PREFIX}"
          region: "${AWS_REGION}"
          tag: "${CIRCLE_SHA1}"
      - aws-ecs/deploy-service-update:
          requires:
            - aws-ecr/build_and_push_image
          aws-region: "${AWS_REGION}"
          family: "${AWS_RESOURCE_NAME_PREFIX}-service"
          cluster-name: "${AWS_RESOURCE_NAME_PREFIX}-cluster"
          container-image-name-updates: "container=${AWS_RESOURCE_NAME_PREFIX}-service,tag=${CIRCLE_SHA1}"
```