### PR TITLE
Allow promoting of orb to production to be skipped

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -261,7 +261,13 @@ jobs:
       - when:
           condition: <<parameters.to-prod>>
           steps:
-            - run: circleci orb publish promote circleci/aws-ecs@dev:$CIRCLE_BRANCH-$CIRCLE_SHA1 <<parameters.release-type>> --token $CIRCLE_TOKEN
+            - run:
+                name: Promote orb to production
+                command: |
+                  if [ "${SKIP_PROD_PUBLISH}" != "true" ]
+                  then
+                    circleci orb publish promote circleci/aws-ecs@dev:$CIRCLE_BRANCH-$CIRCLE_SHA1 <<parameters.release-type>> --token $CIRCLE_TOKEN
+                  fi
 
 commands:
   test-deployment:


### PR DESCRIPTION
Add SKIP_PROD_PUBLISH project env var to enable skipping of publishing to production when the var value is "true". This is useful for preventing unnecessary version increments for times when a build of the master branch is run but there are no actual changes to the orb source.