### PR TITLE
Add tests for service-name parameter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -470,6 +470,7 @@ workflows:
           aws-access-key-id: "${AWS_ACCESS_KEY_ID}"
           aws-region: "${AWS_DEFAULT_REGION}"
           family: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
+          service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
           cluster-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
           container-env-var-updates: "container=${AWS_RESOURCE_NAME_PREFIX_EC2}-service,name=VERSION_INFO,value=\"${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}\",container=${AWS_RESOURCE_NAME_PREFIX_EC2}-service,name=BUILD_DATE,value=$(date)"
           verify-revision-is-deployed: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,6 +160,12 @@ jobs:
       aws-resource-name-prefix:
         description: "Prefix that the AWS resources for this launch type share"
         type: string
+      family-name:
+        description: "Family name"
+        type: string
+      service-name:
+        description: "Service name"
+        type: string
       docker-image-namespace:
         description: "The namespace in which the Docker image was published"
         type: string
@@ -192,7 +198,8 @@ jobs:
             eval $(aws ecr get-login --region $AWS_DEFAULT_REGION --no-include-email)
             docker push $FULL_IMAGE_NAME
       - aws-ecs/update-service:
-          family: "<< parameters.aws-resource-name-prefix >>-service"
+          family: "<< parameters.family-name >>"
+          service-name: "<< parameters.service-name >>"
           cluster-name: "<< parameters.aws-resource-name-prefix >>-cluster"
           container-image-name-updates: "container=<< parameters.aws-resource-name-prefix >>-service,image-and-tag=$FULL_IMAGE_NAME"
           container-env-var-updates: "container=<< parameters.aws-resource-name-prefix >>-service,name=VERSION_INFO,value=\"${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}\",container=<< parameters.aws-resource-name-prefix >>-service,name=BUILD_DATE,value=$(date)"
@@ -441,6 +448,8 @@ workflows:
           requires:
             - ec2_set-up-test-env-dev
           aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
+          family-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
+          service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
           docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
           docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}:${CIRCLE_SHA1}"
           filters:
@@ -454,6 +463,8 @@ workflows:
           requires:
             - fargate_set-up-test-env-dev
           aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
+          family-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
+          service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
           docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
           docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}:${CIRCLE_SHA1}"
           filters:
@@ -469,8 +480,8 @@ workflows:
             - ec2_test-update-service-command-dev
           aws-access-key-id: "${AWS_ACCESS_KEY_ID}"
           aws-region: "${AWS_DEFAULT_REGION}"
-          family: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
-          service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
+          family: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
+          service: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
           cluster-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
           container-env-var-updates: "container=${AWS_RESOURCE_NAME_PREFIX_EC2}-service,name=VERSION_INFO,value=\"${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}\",container=${AWS_RESOURCE_NAME_PREFIX_EC2}-service,name=BUILD_DATE,value=$(date)"
           verify-revision-is-deployed: true
@@ -581,6 +592,8 @@ workflows:
           requires:
             - ec2_set-up-test-env-master
           aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
+          family-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
+          service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
           docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
           docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}:${CIRCLE_SHA1}"
           filters:
@@ -594,6 +607,8 @@ workflows:
           requires:
             - fargate_set-up-test-env-master
           aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
+          family-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
+          service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
           docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
           docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}:${CIRCLE_SHA1}"
           filters:
@@ -609,7 +624,8 @@ workflows:
             - ec2_test-update-service-command-master
           aws-access-key-id: "${AWS_ACCESS_KEY_ID}"
           aws-region: "${AWS_DEFAULT_REGION}"
-          family: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
+          family: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
+          service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
           cluster-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
           container-env-var-updates: "container=${AWS_RESOURCE_NAME_PREFIX_EC2}-service,name=VERSION_INFO,value=\"${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}\",container=${AWS_RESOURCE_NAME_PREFIX_EC2}-service,name=BUILD_DATE,value=$(date)"
           verify-revision-is-deployed: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -481,7 +481,7 @@ workflows:
           aws-access-key-id: "${AWS_ACCESS_KEY_ID}"
           aws-region: "${AWS_DEFAULT_REGION}"
           family: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
-          service: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
+          service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
           cluster-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
           container-env-var-updates: "container=${AWS_RESOURCE_NAME_PREFIX_EC2}-service,name=VERSION_INFO,value=\"${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}\",container=${AWS_RESOURCE_NAME_PREFIX_EC2}-service,name=BUILD_DATE,value=$(date)"
           verify-revision-is-deployed: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -463,8 +463,8 @@ workflows:
           requires:
             - fargate_set-up-test-env-dev
           aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
-          family-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
-          service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
+          family-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
+          service-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
           docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
           docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}:${CIRCLE_SHA1}"
           filters:
@@ -607,8 +607,8 @@ workflows:
           requires:
             - fargate_set-up-test-env-master
           aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
-          family-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
-          service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
+          family-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
+          service-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
           docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
           docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}:${CIRCLE_SHA1}"
           filters:

--- a/tests/terraform_setup/ec2/cloudformation-templates/public-service.yml
+++ b/tests/terraform_setup/ec2/cloudformation-templates/public-service.yml
@@ -10,6 +10,10 @@ Parameters:
     Type: String
     Default: nginx
     Description: A name for the service
+  FamilyName:
+    Type: String
+    Default: nginx
+    Description: A name for the task definition family
   ImageUrl:
     Type: String
     Default: nginx
@@ -59,7 +63,7 @@ Resources:
   TaskDefinition:
     Type: AWS::ECS::TaskDefinition
     Properties:
-      Family: !Ref 'ServiceName'
+      Family: !Ref 'FamilyName'
       Cpu: !Ref 'TaskCpu'
       Memory: !Ref 'TaskMemory'
       TaskRoleArn:

--- a/tests/terraform_setup/ec2/terraform.tf
+++ b/tests/terraform_setup/ec2/terraform.tf
@@ -25,6 +25,8 @@ locals {
   aws_ecs_cluster_name = "${var.aws_resource_prefix}-cluster"
   # The name of the ECS service to be created
   aws_ecs_service_name = "${var.aws_resource_prefix}-service"
+  # The name of the ECS task definition family to be created
+  aws_ecs_family_name = "${var.aws_resource_prefix}-family"
 }
 
 resource "aws_ecr_repository" "demo-app-repository" {
@@ -54,6 +56,7 @@ resource "aws_cloudformation_stack" "ecs_service" {
     ContainerPort = 8080
     StackName = "${local.aws_vpc_stack_name}"
     ServiceName = "${local.aws_ecs_service_name}"
+    FamilyName = "${local.aws_ecs_family_name}"
     # Note: Since ImageUrl parameter is not specified, the Service
     # will be deployed with the 1st container using the
     # nginx image when created


### PR DESCRIPTION
Update the EC2 integration test setup to use a service name that is different from the task definition family name, to facilitate testing of the service-name parameter added in version 0.0.5 (See: https://github.com/CircleCI-Public/aws-ecs-orb/pull/6)

There are no changes to the orb source, and this branch was previously used to test https://github.com/CircleCI-Public/aws-ecs-orb/pull/6, so I would like to merge in the changes so that going forward we'll continue to test the service-name parameter.

Note: The Fargate integration test setup will still use a service name that is the same as the family name, to serve as a test for that use case. And ideally we should add a regression test for testing the case of no service-name parameter being supplied.