### PR TITLE
IAM Permissions

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -259,3 +259,16 @@ workflows:
     jobs:
       - update-tag
 ```
+
+## Permissions
+
+You will need to add an IAM policy to your CircleCI IAM user to allow the following permissions:
+
+| Permission |
+| ---- |
+| `ecs:DescribeTaskDefinition` |
+| `ecs:RegisterTaskDefinition` |
+| `ecs:UpdateService` |
+| `iam:PassRole` |
+
+- `iam:PassRole` is required to (re)set any container roles or task execution roles during the deployment that you have already configured via the UI. These are resource-based so you can whitelist which roles your CircleCI IAM role can set, if desired.


### PR DESCRIPTION
After setting this up Tuesday/today, it took a few (tens of) attempts to whitelist the IAM permissions required for this orb. I think it would be beneficial to note the IAM permissions required to perform the actions in these orbs. This could also apply to other AWS orbs too.

This PR is a short addition to the bottom of the README, to suggest which permissions are required and why. I realise this is in no way a comprehensive list for the actions in this orb, let alone all the actions in all the AWS orbs.

PS: Shout out to @JustinC474 👋 Nice meeting you yesterday at AWS Summit London!