### PR TITLE
use 0.0.10 version in examples

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -26,7 +26,7 @@ version: 2.1
 
 orbs:
   aws-cli: circleci/aws-cli@0.1.4
-  aws-ecs: circleci/aws-ecs@0.1.0
+  aws-ecs: circleci/aws-ecs@0.0.10
 
 jobs:
   update-tag:

--- a/src/orb.yml.hbs
+++ b/src/orb.yml.hbs
@@ -13,7 +13,7 @@ examples:
 
       orbs:
         aws-ecr: circleci/aws-ecr@0.0.4
-        aws-ecs: circleci/aws-ecs@0.0.3
+        aws-ecs: circleci/aws-ecs@0.0.10
 
       workflows:
         build-and-deploy:
@@ -37,7 +37,7 @@ examples:
 
       orbs:
         aws-cli: circleci/aws-cli@0.1.4
-        aws-ecs: circleci/aws-ecs@0.0.3
+        aws-ecs: circleci/aws-ecs@0.0.10
 
       jobs:
         update-tag:
@@ -65,7 +65,7 @@ examples:
 
       orbs:
         aws-cli: circleci/aws-cli@0.1.4
-        aws-ecs: circleci/aws-ecs@0.0.3
+        aws-ecs: circleci/aws-ecs@0.0.10
 
       jobs:
         verify-deployment:


### PR DESCRIPTION
Since 0.0.10 contains a bug fix for https://github.com/CircleCI-Public/aws-ecs-orb/issues/30, it would be good to update our examples to reference that version.