### PR TITLE
[CIRCLE-21355][CIRCLE-21358] Add blue/green deployment type ECS service setup to tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,13 +115,16 @@ jobs:
 
   set-up-test-env:
     parameters:
+      terraform-image:
+        type: string
+        # Pin to terraform 0.11
+        default: hashicorp/terraform@sha256:330bef7401e02e757e6fa2de69f398fd29fcbfafe2a3b9e8f150486fbcd7915b
       aws-resource-name-prefix:
         type: string
       terraform-config-dir:
         type: string
     docker:
-      # Pin to terraform 0.11
-      - image: hashicorp/terraform@sha256:330bef7401e02e757e6fa2de69f398fd29fcbfafe2a3b9e8f150486fbcd7915b
+      - image: << parameters.terraform-image >>
     steps:
       - run:
           name: Check if test env should be set up
@@ -212,13 +215,16 @@ jobs:
 
   tear-down-test-env:
     parameters:
+      terraform-image:
+        type: string
+        # Pin to terraform 0.11
+        default: hashicorp/terraform@sha256:330bef7401e02e757e6fa2de69f398fd29fcbfafe2a3b9e8f150486fbcd7915b
       aws-resource-name-prefix:
         type: string
       terraform-config-dir:
         type: string
     docker:
-      # Pin to terraform 0.11
-      - image: hashicorp/terraform@sha256:330bef7401e02e757e6fa2de69f398fd29fcbfafe2a3b9e8f150486fbcd7915b
+      - image: << parameters.terraform-image >>
     steps:
       - run:
           name: Check if test env should be destroyed
@@ -421,6 +427,16 @@ workflows:
             tags:
               only: /integration-.*/
 
+      - build-test-app:
+          name: codedeploy_fargate_build-test-app-dev
+          docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+          docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /integration-.*/
+
       - set-up-test-env:
           name: ec2_set-up-test-env-dev
           requires:
@@ -439,6 +455,19 @@ workflows:
             - fargate_build-test-app-dev
           aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
           terraform-config-dir: "tests/terraform_setup/fargate"
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /integration-.*/
+
+      - set-up-test-env:
+          name: codedeploy_fargate_set-up-test-env-dev
+          requires:
+            - codedeploy_fargate_build-test-app-dev
+          terraform-image: "hashicorp/terraform:latest"
+          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
+          terraform-config-dir: "tests/terraform_setup/fargate_codedeploy"
           filters:
             branches:
               ignore: /.*/
@@ -545,6 +574,19 @@ workflows:
             tags:
               only: /integration-.*/
 
+      - tear-down-test-env:
+          name: codedeploy_fargate_tear-down-test-env-dev
+          requires:
+            - codedeploy_fargate_set-up-test-env-dev
+          terraform-image: "hashicorp/terraform:latest"
+          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
+          terraform-config-dir: "tests/terraform_setup/fargate_codedeploy"
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /integration-.*/
+
       - build-test-app:
           name: ec2_build-test-app-master
           docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
@@ -559,6 +601,16 @@ workflows:
           name: fargate_build-test-app-master
           docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
           docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}:${CIRCLE_SHA1}"
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /master-.*/
+
+      - build-test-app:
+          name: codedeploy_fargate_build-test-app-master
+          docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+          docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
           filters:
             branches:
               ignore: /.*/
@@ -583,6 +635,18 @@ workflows:
             - fargate_build-test-app-master
           aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
           terraform-config-dir: "tests/terraform_setup/fargate"
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /master-.*/
+
+      - set-up-test-env:
+          name: codedeploy_fargate_set-up-test-env-master
+          requires:
+            - codedeploy_fargate_build-test-app-master
+          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
+          terraform-config-dir: "tests/terraform_setup/fargate_codedeploy"
           filters:
             branches:
               ignore: /.*/
@@ -689,6 +753,18 @@ workflows:
             tags:
               only: /master-.*/
 
+      - tear-down-test-env:
+          name: codedeploy_fargate_tear-down-test-env-master
+          requires:
+            - codedeploy_fargate_set-up-test-env-master
+          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
+          terraform-config-dir: "tests/terraform_setup/fargate_codedeploy"
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /master-.*/
+
       - publish-orb:
           name: publish-prod-orb
           to-prod: true
@@ -696,6 +772,7 @@ workflows:
           requires:
             - fargate_tear-down-test-env-master
             - ec2_tear-down-test-env-master
+            - codedeploy_fargate_tear-down-test-env-master
           filters:
             branches:
               ignore: /.*/

--- a/dev-docs/README.md
+++ b/dev-docs/README.md
@@ -1,4 +1,30 @@
-# Development
+# Notes for Internal Contributors
 
-## Tips
+The notes here are primarily targeted at internal (CircleCI) contributors to the orb but could be of reference to fork owners who wish to run the tests with their own AWS account.
 
+## Building
+
+### Required Project Environment Variables
+
+The following [project environment variables](https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-project) must be set for the project on CircleCI via the project settings page, before the project can be built successfully.
+
+| Variable                       | Description                           |
+| -------------------------------| --------------------------------------|
+| `AWS_ACCESS_KEY_ID`            | Picked up by the AWS CLI              |
+| `AWS_SECRET_ACCESS_KEY`        | Picked up by the AWS CLI              |
+| `AWS_DEFAULT_REGION`           | Picked up by the AWS CLI              |
+| `AWS_ACCOUNT_ID`               | AWS account id                        |
+| `CIRCLECI_API_KEY`             | Used by the `queue` orb               |
+| `AWS_RESOURCE_NAME_PREFIX_EC2` | Prefix used to name AWS resources for EC2 launch type integration tests                                        |
+| `AWS_RESOURCE_NAME_PREFIX_FARGATE` | Prefix used to name AWS resources for Fargate launch type integration tests                               |
+| `AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE` | Prefix used to name AWS resources for Fargate launch type integration tests that use CodeDeploy |
+| `SKIP_TEST_ENV_CREATION`       | Whether to skip test env setup        |
+| `SKIP_TEST_ENV_TEARDOWN`       | Whether to skip test env teardown     |
+
+### Required Context and Context Environment Variables
+
+The `orb-publishing` context is referenced in the build. In particular, the following [context environment variables](https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-context) must be set in the `orb-publishing` context, before the project can be built successfully.
+
+| Variable                       | Description                      |
+| -------------------------------| ---------------------------------|
+| `CIRCLE_TOKEN`                 | CircleCI API token used to publish the orb  |

--- a/tests/terraform_setup/fargate_codedeploy/alb.tf
+++ b/tests/terraform_setup/fargate_codedeploy/alb.tf
@@ -1,0 +1,66 @@
+# Ref: https://github.com/bradford-hamilton/terraform-ecs-fargate/
+
+resource "aws_alb" "main" {
+  name            = "cb-load-balancer"
+  subnets         = aws_subnet.public.*.id
+  security_groups = [aws_security_group.lb.id]
+}
+
+resource "aws_alb_target_group" "green" {
+  name        = "target-group-green"
+  port        = 80
+  protocol    = "HTTP"
+  vpc_id      = aws_vpc.main.id
+  target_type = "ip"
+
+  health_check {
+    healthy_threshold   = "3"
+    interval            = "30"
+    protocol            = "HTTP"
+    matcher             = "200"
+    timeout             = "3"
+    path                = var.health_check_path
+    unhealthy_threshold = "2"
+  }
+}
+
+resource "aws_alb_target_group" "blue" {
+  name        = "target-group-blue"
+  port        = 80
+  protocol    = "HTTP"
+  vpc_id      = aws_vpc.main.id
+  target_type = "ip"
+
+  health_check {
+    healthy_threshold   = "3"
+    interval            = "30"
+    protocol            = "HTTP"
+    matcher             = "200"
+    timeout             = "3"
+    path                = var.health_check_path
+    unhealthy_threshold = "2"
+  }
+}
+
+# Redirect all traffic from the ALB to the target group
+resource "aws_alb_listener" "front_end_green" {
+  load_balancer_arn = aws_alb.main.id
+  port              = var.app_port_green
+  protocol          = "HTTP"
+
+  default_action {
+    target_group_arn = aws_alb_target_group.green.id
+    type             = "forward"
+  }
+}
+
+resource "aws_alb_listener" "front_end_blue" {
+  load_balancer_arn = aws_alb.main.id
+  port              = var.app_port
+  protocol          = "HTTP"
+
+  default_action {
+    target_group_arn = aws_alb_target_group.blue.id
+    type             = "forward"
+  }
+}

--- a/tests/terraform_setup/fargate_codedeploy/ecs.tf
+++ b/tests/terraform_setup/fargate_codedeploy/ecs.tf
@@ -1,0 +1,139 @@
+resource "aws_ecs_cluster" "ecs_cluster" {
+  name = "${var.aws_resource_prefix}-cluster"
+}
+
+resource "aws_ecs_task_definition" "ecs_task_dfn" {
+  family = "${var.aws_resource_prefix}"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = 1024
+  memory                   = 2048
+
+  container_definitions = <<DEFINITION
+[
+  {
+    "cpu": 128,
+    "portMappings": [{
+      "containerPort": ${var.app_port},
+      "hostPort": ${var.app_port}
+    }],
+    "environment": [{
+      "name": "SECRET",
+      "value": "KEY"
+    }],
+    "essential": true,
+    "image": "nginx:latest",
+    "memory": 128,
+    "memoryReservation": 64,
+    "name": "${var.aws_resource_prefix}-service"
+  }
+]
+DEFINITION
+}
+
+resource "aws_ecs_service" "ecs_service" {
+  name          = "${var.aws_resource_prefix}"
+  cluster       = "${aws_ecs_cluster.ecs_cluster.id}"
+  desired_count = 2
+  task_definition = "${aws_ecs_task_definition.ecs_task_dfn.arn}"
+  launch_type = "FARGATE"
+
+  deployment_controller {
+      type = "CODE_DEPLOY"
+  }
+
+  network_configuration {
+    security_groups  = [aws_security_group.ecs_tasks.id]
+    subnets          = aws_subnet.private.*.id
+    assign_public_ip = true
+  }
+
+  load_balancer {
+    target_group_arn = aws_alb_target_group.blue.id
+    container_name   = "${var.aws_resource_prefix}-service"
+    container_port   = var.app_port
+  }
+
+  depends_on = [aws_alb_listener.front_end_blue, aws_iam_role_policy_attachment.ecs_task_execution_role]
+
+}
+
+# https://docs.aws.amazon.com/AmazonECS/latest/developerguide/codedeploy_IAM_role.html
+resource "aws_iam_role" "codedeployrole" {
+  name = "${var.aws_resource_prefix}-role"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "codedeploy.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "AWSCodeDeployRole" {
+  policy_arn = "arn:aws:iam::aws:policy/AWSCodeDeployRoleForECS"
+  role       = "${aws_iam_role.codedeployrole.name}"
+}
+
+resource "aws_codedeploy_app" "codedeployapp" {
+  compute_platform = "ECS"
+  name             = "${var.aws_resource_prefix}-codedeployapp"
+}
+
+resource "aws_codedeploy_deployment_group" "deployment_group" {
+  app_name               = "${aws_codedeploy_app.codedeployapp.name}"
+  deployment_config_name = "CodeDeployDefault.ECSAllAtOnce"
+  deployment_group_name  = "${var.aws_resource_prefix}-codedeploygroup"
+  service_role_arn       = "${aws_iam_role.codedeployrole.arn}"
+
+  auto_rollback_configuration {
+    enabled = true
+    events  = ["DEPLOYMENT_FAILURE"]
+  }
+
+  blue_green_deployment_config {
+    deployment_ready_option {
+      action_on_timeout = "CONTINUE_DEPLOYMENT"
+    }
+
+    terminate_blue_instances_on_deployment_success {
+      action                           = "TERMINATE"
+      termination_wait_time_in_minutes = 5
+    }
+  }
+
+  deployment_style {
+    deployment_option = "WITH_TRAFFIC_CONTROL"
+    deployment_type   = "BLUE_GREEN"
+  }
+
+  ecs_service {
+    cluster_name = "${aws_ecs_cluster.ecs_cluster.name}"
+    service_name = "${aws_ecs_service.ecs_service.name}"
+  }
+
+  load_balancer_info {
+    target_group_pair_info {
+      prod_traffic_route {
+        listener_arns = ["${aws_alb_listener.front_end_blue.arn}"]
+      }
+
+      target_group {
+        name = "${aws_alb_target_group.blue.name}"
+      }
+
+      target_group {
+        name = "${aws_alb_target_group.green.name}"
+      }
+    }
+  }
+}

--- a/tests/terraform_setup/fargate_codedeploy/network.tf
+++ b/tests/terraform_setup/fargate_codedeploy/network.tf
@@ -1,0 +1,69 @@
+# Ref: https://github.com/bradford-hamilton/terraform-ecs-fargate/
+
+# Fetch AZs in the current region
+data "aws_availability_zones" "available" {
+}
+
+resource "aws_vpc" "main" {
+  cidr_block = "172.17.0.0/16"
+}
+
+# Create var.az_count private subnets, each in a different AZ
+resource "aws_subnet" "private" {
+  count             = "${var.az_count}"
+  cidr_block        = cidrsubnet(aws_vpc.main.cidr_block, 8, count.index)
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+  vpc_id            = aws_vpc.main.id
+}
+
+# Create var.az_count public subnets, each in a different AZ
+resource "aws_subnet" "public" {
+  count                   = var.az_count
+  cidr_block              = cidrsubnet(aws_vpc.main.cidr_block, 8, var.az_count + count.index)
+  availability_zone       = data.aws_availability_zones.available.names[count.index]
+  vpc_id                  = aws_vpc.main.id
+  map_public_ip_on_launch = true
+}
+
+# Internet Gateway for the public subnet
+resource "aws_internet_gateway" "gw" {
+  vpc_id = aws_vpc.main.id
+}
+
+# Route the public subnet traffic through the IGW
+resource "aws_route" "internet_access" {
+  route_table_id         = aws_vpc.main.main_route_table_id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.gw.id
+}
+
+# Create a NAT gateway with an Elastic IP for each private subnet to get internet connectivity
+resource "aws_eip" "gw" {
+  count      = var.az_count
+  vpc        = true
+  depends_on = [aws_internet_gateway.gw]
+}
+
+resource "aws_nat_gateway" "gw" {
+  count         = var.az_count
+  subnet_id     = element(aws_subnet.public.*.id, count.index)
+  allocation_id = element(aws_eip.gw.*.id, count.index)
+}
+
+# Create a new route table for the private subnets, make it route non-local traffic through the NAT gateway to the internet
+resource "aws_route_table" "private" {
+  count  = var.az_count
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = element(aws_nat_gateway.gw.*.id, count.index)
+  }
+}
+
+# Explicitly associate the newly created route tables to the private subnets (so they don't default to the main route table)
+resource "aws_route_table_association" "private" {
+  count          = var.az_count
+  subnet_id      = element(aws_subnet.private.*.id, count.index)
+  route_table_id = element(aws_route_table.private.*.id, count.index)
+}

--- a/tests/terraform_setup/fargate_codedeploy/outputs.tf
+++ b/tests/terraform_setup/fargate_codedeploy/outputs.tf
@@ -1,0 +1,3 @@
+output "alb_hostname" {
+  value = aws_alb.main.dns_name
+}

--- a/tests/terraform_setup/fargate_codedeploy/roles.tf
+++ b/tests/terraform_setup/fargate_codedeploy/roles.tf
@@ -1,0 +1,40 @@
+# ECS task execution role data
+data "aws_iam_policy_document" "ecs_task_execution_role" {
+  version = "2012-10-17"
+  statement {
+    sid = ""
+    effect = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+# ECS task execution role
+resource "aws_iam_role" "ecs_task_execution_role" {
+  name               = "${var.aws_resource_prefix}-task_execution_role"
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_execution_role.json
+}
+
+# ECS task execution role policy attachment
+resource "aws_iam_role_policy_attachment" "ecs_task_execution_role" {
+  role       = aws_iam_role.ecs_task_execution_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+# ECS auto scale role data
+data "aws_iam_policy_document" "ecs_auto_scale_role" {
+  version = "2012-10-17"
+  statement {
+    effect = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["application-autoscaling.amazonaws.com"]
+    }
+  }
+}

--- a/tests/terraform_setup/fargate_codedeploy/security.tf
+++ b/tests/terraform_setup/fargate_codedeploy/security.tf
@@ -1,0 +1,57 @@
+# Ref: https://github.com/bradford-hamilton/terraform-ecs-fargate/
+
+# ALB Security Group: Edit to restrict access to the application
+resource "aws_security_group" "lb" {
+  name        = "cb-load-balancer-security-group"
+  description = "controls access to the ALB"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    protocol    = "tcp"
+    from_port   = var.app_port
+    to_port     = var.app_port
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    protocol    = "tcp"
+    from_port   = var.app_port_green
+    to_port     = var.app_port_green
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    protocol    = "-1"
+    from_port   = 0
+    to_port     = 0
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+# Traffic to the ECS cluster should only come from the ALB
+resource "aws_security_group" "ecs_tasks" {
+  name        = "cb-ecs-tasks-security-group"
+  description = "allow inbound access from the ALB only"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    protocol        = "tcp"
+    from_port       = var.app_port
+    to_port         = var.app_port
+    security_groups = [aws_security_group.lb.id]
+  }
+
+  ingress {
+    protocol        = "tcp"
+    from_port       = var.app_port_green
+    to_port         = var.app_port_green
+    security_groups = [aws_security_group.lb.id]
+  }
+
+  egress {
+    protocol    = "-1"
+    from_port   = 0
+    to_port     = 0
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/tests/terraform_setup/fargate_codedeploy/terraform.tf
+++ b/tests/terraform_setup/fargate_codedeploy/terraform.tf
@@ -1,0 +1,24 @@
+terraform {
+  backend "s3" {
+    bucket = "aws-ecs-orb-terraform-state-bucket-codedeploy-fargate"
+    key    = "tf/state"
+    region = "us-east-1"
+    dynamodb_table = "aws-ecs-orb-terraform-state-lock-db-codedeploy-fargate"
+  }
+}
+
+provider "aws" {
+  access_key = "${var.aws_access_key}"
+  secret_key = "${var.aws_secret_key}"
+  region     = "${var.aws_region}"
+  version = "~> 2.00"
+}
+
+locals {
+  # The name of the ECR repository to be created
+  aws_ecr_repository_name = "${var.aws_resource_prefix}"
+}
+
+resource "aws_ecr_repository" "demo-app-repository" {
+  name = "${local.aws_ecr_repository_name}"
+}

--- a/tests/terraform_setup/fargate_codedeploy/variables.tf
+++ b/tests/terraform_setup/fargate_codedeploy/variables.tf
@@ -1,0 +1,25 @@
+variable "aws_access_key" {}
+variable "aws_secret_key" {}
+variable "aws_account_id" {}
+variable "aws_region" {
+  description = "AWS region e.g. us-east-1 (Please specify a region supported by the Fargate launch type)"
+}
+variable "aws_resource_prefix" {
+  description = "Prefix to be used in the naming of the created AWS resources e.g. ecs-fargate"
+}
+
+variable "az_count" {
+  default = "2"
+}
+
+variable "health_check_path" {
+  default = "/"
+}
+
+variable "app_port" {
+  default = "80"
+}
+
+variable "app_port_green" {
+  default = "8080"
+}

--- a/tests/terraform_setup/state_init/terraform.tf
+++ b/tests/terraform_setup/state_init/terraform.tf
@@ -23,6 +23,14 @@ resource "aws_s3_bucket" "terraform-state-storage-s3-fargate" {
     }
 }
 
+resource "aws_s3_bucket" "terraform-state-storage-s3-codedeploy-fargate" {
+    bucket = "aws-ecs-orb-terraform-state-bucket-codedeploy-fargate"
+
+    versioning {
+      enabled = true
+    }
+}
+
 # create a dynamodb table for locking the state file
 resource "aws_dynamodb_table" "dynamodb-terraform-state-lock-ec2" {
   name = "aws-ecs-orb-terraform-state-lock-db-ec2"
@@ -38,6 +46,18 @@ resource "aws_dynamodb_table" "dynamodb-terraform-state-lock-ec2" {
 
 resource "aws_dynamodb_table" "dynamodb-terraform-state-lock-fargate" {
   name = "aws-ecs-orb-terraform-state-lock-db-fargate"
+  hash_key = "LockID"
+  read_capacity = 20
+  write_capacity = 20
+ 
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+}
+
+resource "aws_dynamodb_table" "dynamodb-terraform-state-lock-codedeploy-fargate" {
+  name = "aws-ecs-orb-terraform-state-lock-db-codedeploy-fargate"
   hash_key = "LockID"
   read_capacity = 20
   write_capacity = 20


### PR DESCRIPTION
Update the integration tests to set up an environment for testing future support for blue/green deployment type (CodeDeploy) ECS services.