### PR TITLE
Use environment variables for AWS parameters

### DIFF
--- a/src/orb.yml.hbs
+++ b/src/orb.yml.hbs
@@ -156,20 +156,24 @@ jobs:
         type: string
         default: circleci/python:3.7.1
       aws-access-key-id:
-        description: |
-          AWS access key id for IAM role. Defaulted to $AWS_ACCESS_KEY_ID
-        type: string
-        default: $AWS_ACCESS_KEY_ID
+        description: >
+          AWS access key id for IAM role. Set this to the name of
+          the environment variable you will set to hold this
+          value, defaults to AWS_ACCESS_KEY.
+        type: env_var_name
+        default: AWS_ACCESS_KEY_ID
       aws-secret-access-key:
-        description: |
-          AWS secret key for IAM role. Defaulted to $AWS_SECRET_ACCESS_KEY
-        type: string
-        default: $AWS_SECRET_ACCESS_KEY
+        description: >
+          AWS secret key for IAM role. Set this to the name of
+          the environment variable you will set to hold this
+          value, defaults to AWS_SECRET_ACCESS_KEY
+        type: env_var_name
+        default: AWS_SECRET_ACCESS_KEY
       aws-region:
         description:
-          AWS region to operate in. Defaulted to $AWS_REGION
-        type: string
-        default: $AWS_REGION
+          Environment variable for AWS region to operate in, defaults to AWS_REGION
+        type: env_var_name
+        default: AWS_REGION
       family:
         description:
           "Name of the task definition's family."
@@ -292,20 +296,24 @@ jobs:
         type: string
         default: circleci/python:3.7.1
       aws-access-key-id:
-        description: |
-          AWS access key id for IAM role. Defaulted to $AWS_ACCESS_KEY_ID
-        type: string
-        default: $AWS_ACCESS_KEY_ID
+        description: >
+          AWS access key id for IAM role. Set this to the name of
+          the environment variable you will set to hold this
+          value, defaults to AWS_ACCESS_KEY.
+        type: env_var_name
+        default: AWS_ACCESS_KEY_ID
       aws-secret-access-key:
-        description: |
-          AWS secret key for IAM role. Defaulted to $AWS_SECRET_ACCESS_KEY
-        type: string
-        default: $AWS_SECRET_ACCESS_KEY
+        description: >
+          AWS secret key for IAM role. Set this to the name of
+          the environment variable you will set to hold this
+          value, defaults to AWS_SECRET_ACCESS_KEY
+        type: env_var_name
+        default: AWS_SECRET_ACCESS_KEY
       aws-region:
         description:
-          AWS region to operate in. Defaulted to $AWS_REGION
-        type: string
-        default: $AWS_REGION
+          Environment variable for AWS region to operate in, defaults to AWS_REGION
+        type: env_var_name
+        default: AWS_REGION
       family:
         description:
           "Name of the task definition's family."
@@ -349,20 +357,24 @@ jobs:
         type: string
         default: circleci/python:3.7.1
       aws-access-key-id:
-        description: |
-          AWS access key id for IAM role. Defaulted to $AWS_ACCESS_KEY_ID
-        type: string
-        default: $AWS_ACCESS_KEY_ID
+        description: >
+          AWS access key id for IAM role. Set this to the name of
+          the environment variable you will set to hold this
+          value, defaults to AWS_ACCESS_KEY.
+        type: env_var_name
+        default: AWS_ACCESS_KEY_ID
       aws-secret-access-key:
-        description: |
-          AWS secret key for IAM role. Defaulted to $AWS_SECRET_ACCESS_KEY
-        type: string
-        default: $AWS_SECRET_ACCESS_KEY
+        description: >
+          AWS secret key for IAM role. Set this to the name of
+          the environment variable you will set to hold this
+          value, defaults to AWS_SECRET_ACCESS_KEY
+        type: env_var_name
+        default: AWS_SECRET_ACCESS_KEY
       aws-region:
         description:
-          AWS region to operate in. Defaulted to $AWS_REGION
-        type: string
-        default: $AWS_REGION
+          Environment variable for AWS region to operate in, defaults to AWS_REGION
+        type: env_var_name
+        default: AWS_REGION
       cluster:
         description:
           "The name or ARN of the cluster on which to run the task."


### PR DESCRIPTION
Make it consistent with [aws-ecr-orb](https://github.com/CircleCI-Public/aws-ecr-orb), [aws-cli-orb](https://github.com/CircleCI-Public/aws-cli-orb) and [circleci-orbs](https://github.com/CircleCI-Public/circleci-orbs)'s aws-s3.

Fix #9.