### PR TITLE
Update the orb description to mention AWS Fargate launch type support

### DIFF
--- a/src/orb.yml.hbs
+++ b/src/orb.yml.hbs
@@ -1,7 +1,9 @@
 version: 2.1
 description: |
-  An orb for working with Amazon Elastic Container Service (ECS)
-  AWS ECS Orb Source: https://github.com/CircleCI-Public/aws-ecs-orb
+  An orb for working with Amazon Elastic Container Service (ECS).
+  Supports the EC2 and Fargate launch types and Blue/Green deployment
+  via CodeDeploy.
+  Repository link: https://github.com/CircleCI-Public/aws-ecs-orb
 
 orbs:
   aws-cli: circleci/aws-cli@0.1.4


### PR DESCRIPTION
Update the orb description to mention Fargate, to improve discoverability of the aws-ecs orb in the orb registry for AWS Fargate users.