### PR TITLE
Added const statement in variable declaration (fs)

### DIFF
--- a/tools/orb-template-processor.js
+++ b/tools/orb-template-processor.js
@@ -1,5 +1,5 @@
 const Handlebars = require('handlebars'),
-fs = require('fs');
+const fs = require('fs');
 const templateContents = fs.readFileSync(process.argv[2]).toString();
 const containerDefsScript = fs.readFileSync("src/python/update_container_definitions.py").toString();
 const getTaskDefScript = fs.readFileSync("src/python/get_task_definition_value.py").toString();


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [ ] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

It's a good practise to declare variables with let, const or var based use case to preserve scope.

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

Changed `fs = require('fs');` to `const fs = require('fs');`