### PR TITLE
Enhancement: Add overrides parameter to run-task job and command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -246,6 +246,47 @@ jobs:
                 service-name: "<< parameters.aws-resource-name-prefix >>-service"
                 cluster-name: "<< parameters.aws-resource-name-prefix >>-cluster"
 
+  set-up-run-task-test:
+    docker:
+      - image: circleci/python:3.7.1
+    parameters:
+      family-name:
+        description: "Family name"
+        type: string
+    steps:
+      - checkout
+      - aws-cli/install
+      - aws-cli/configure:
+          aws-access-key-id: "$AWS_ACCESS_KEY_ID"
+          aws-region: "$AWS_DEFAULT_REGION"
+      - run:
+          name: Register task definition
+          command: |
+            aws ecs register-task-definition \
+              --family << parameters.family-name >> \
+              --cpu 256 --memory 512 \
+              --container-definitions "[{\"name\":\"sleep\",\"image\":\"busybox\",\"command\":[\"sleep\",\"360\"],\"memory\":256,\"essential\":true}]"
+
+  tear-down-run-task-test:
+    docker:
+      - image: circleci/python:3.7.1
+    parameters:
+      family-name:
+        description: "Family name"
+        type: string
+    steps:
+      - checkout
+      - aws-cli/install
+      - aws-cli/configure:
+          aws-access-key-id: "$AWS_ACCESS_KEY_ID"
+          aws-region: "$AWS_DEFAULT_REGION"
+      - run:
+          name: Deregister task definition
+          command: |
+            TASK_DEFINITION_ARN=$(aws ecs describe-task-definition \
+              --task-definition << parameters.family-name >> | jq -r '.taskDefinition.taskDefinitionArn')
+            aws ecs deregister-task-definition --task-definition ${TASK_DEFINITION_ARN}
+
   tear-down-test-env:
     parameters:
       terraform-image:
@@ -455,6 +496,29 @@ workflows:
           aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
           terraform-config-dir: "tests/terraform_setup/fargate_codedeploy"
 
+      # test run-task job in ec2 env
+      - set-up-run-task-test:
+          name: ec2_set-up-run-task-test
+          requires:
+            - ec2_set-up-test-env
+          family-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360"
+      - aws-ecs/run-task:
+          name: ec2_run-task-test
+          requires:
+            - ec2_set-up-run-task-test
+          cluster: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
+          aws-region: $AWS_DEFAULT_REGION
+          task-definition: "${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360"
+          launch-type: "EC2"
+          awsvpc: false
+          overrides: "{\\\"containerOverrides\\\":[{\\\"name\\\": \\\"sleep\\\", \\\"memory\\\": 512}]}"
+      - tear-down-run-task-test:
+          name: ec2_tear-down-run-task-test
+          requires:
+            - ec2_run-task-test
+          family-name: ecs-test-sleep360
+
+      # test ecs updates
       - test-service-update:
           name: ec2_test-update-service-command
           requires:
@@ -558,6 +622,7 @@ workflows:
           name: ec2_tear-down-test-env
           requires:
             - ec2_test-update-service-job
+            - ec2_tear-down-run-task-test
           aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
           terraform-config-dir: "tests/terraform_setup/ec2"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,8 +143,7 @@ jobs:
     parameters:
       terraform-image:
         type: string
-        # Pin to terraform 0.12
-        default: hashicorp/terraform@sha256:cf9b54657c498378e3fe43f5e36039c9b7d8e620a606fbdc713d63df514fb96d
+        default: hashicorp/terraform:0.12.16
       aws-resource-name-prefix:
         type: string
       terraform-config-dir:
@@ -291,8 +290,7 @@ jobs:
     parameters:
       terraform-image:
         type: string
-        # Pin to terraform 0.12
-        default: hashicorp/terraform@sha256:cf9b54657c498378e3fe43f5e36039c9b7d8e620a606fbdc713d63df514fb96d
+        default: hashicorp/terraform:0.12.16
       aws-resource-name-prefix:
         type: string
       terraform-config-dir:
@@ -492,7 +490,7 @@ workflows:
           name: codedeploy_fargate_set-up-test-env
           requires:
             - codedeploy_fargate_build-test-app
-          terraform-image: "hashicorp/terraform:latest"
+          terraform-image: "hashicorp/terraform:0.12.16"
           aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
           terraform-config-dir: "tests/terraform_setup/fargate_codedeploy"
 
@@ -637,7 +635,7 @@ workflows:
           name: codedeploy_fargate_tear-down-test-env
           requires:
             - codedeploy_fargate_test-update-service-job
-          terraform-image: "hashicorp/terraform:latest"
+          terraform-image: "hashicorp/terraform:0.12.16"
           aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
           terraform-config-dir: "tests/terraform_setup/fargate_codedeploy"
 

--- a/src/orb.yml.hbs
+++ b/src/orb.yml.hbs
@@ -3,7 +3,9 @@ description: |
   An orb for working with Amazon Elastic Container Service (ECS).
   Supports the EC2 and Fargate launch types and Blue/Green deployment
   via CodeDeploy.
-  Repository link: https://github.com/CircleCI-Public/aws-ecs-orb
+
+display:
+  home_url: https://github.com/CircleCI-Public/aws-ecs-orb
 
 orbs:
   aws-cli: circleci/aws-cli@0.1.4
@@ -142,6 +144,7 @@ examples:
                 cluster: "cluster1"
                 task-definition: "myapp"
                 awsvpc: false
+                launch-type: "EC2"
 
       workflows:
         run-task:
@@ -461,6 +464,15 @@ jobs:
         type: enum
         enum: ["ENABLED", "DISABLED"]
         default: "DISABLED"
+      overrides:
+        description: |
+          A list of container overrides in JSON format that specify the name of
+          a container in the specified task definition and the overrides it
+          should receive.
+          Double quotes in the JSON should be escaped e.g.:
+          {\\\"containerOverrides\\\":[{\\\"name\\\": \\\"sleep\\\", \\\"memory\\\": 512}]}
+        type: string
+        default: ""
       tags:
         description: |
           "The metadata that you apply to the task to help you categorize and
@@ -501,6 +513,7 @@ jobs:
           subnet-ids: << parameters.subnet-ids >>
           security-group-ids: << parameters.security-group-ids >>
           assign-public-ip: << parameters.assign-public-ip >>
+          overrides: << parameters.overrides >>
           tags: << parameters.tags >>
           enable-ecs-managed-tags: << parameters.enable-ecs-managed-tags >>
           propagate-tags: << parameters.propagate-tags >>
@@ -975,6 +988,15 @@ commands:
         type: enum
         enum: ["ENABLED", "DISABLED"]
         default: "DISABLED"
+      overrides:
+        description: |
+          A list of container overrides in JSON format that specify the name of
+          a container in the specified task definition and the overrides it
+          should receive.
+          Double quotes in the JSON should be escaped e.g.:
+          {\\\"containerOverrides\\\":[{\\\"name\\\": \\\"sleep\\\", \\\"memory\\\": 512}]}
+        type: string
+        default: ""
       tags:
         description: |
           "The metadata that you apply to the task to help you categorize and
@@ -1010,6 +1032,10 @@ commands:
             if [ ! -z "<<parameters.group>>" ]; then
                 echo "Setting --group"
                 set -- "$@" --group "<<parameters.group>>"
+            fi
+            if [ ! -z "<<parameters.overrides>>" ]; then
+                echo "Setting --overrides"
+                set -- "$@" --overrides "<<parameters.overrides>>"
             fi
             if [ ! -z "<<parameters.tags>>" ]; then
                 echo "Setting --tags"


### PR DESCRIPTION
- Add `overrides` parameter to `run-task` job and command to support `aws ecs run-task`'s `--overrides` option. This resolves https://github.com/CircleCI-Public/aws-ecs-orb/issues/79.
- Add integration test for `run-task` job
- Fix `run-task` example for EC2 environment