### PR TITLE
Set an optional parameter on whether to run update-task-definition in update-service.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -626,6 +626,25 @@ workflows:
                 cluster-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
 
       - aws-ecs/deploy-service-update:
+          name: fargate_test-update-service-skip-registration
+          docker-image-for-job: circleci/python:3.4.9
+          requires:
+            - fargate_test-update-service-job
+          aws-access-key-id: "${AWS_ACCESS_KEY_ID}"
+          aws-region: "${AWS_DEFAULT_REGION}"
+          family: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
+          cluster-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
+          # test skipping registration of a new task definition
+          skip-task-definition-registration: false
+          verify-revision-is-deployed: true
+          max-poll-attempts: 40
+          poll-interval: 10
+          post-steps:
+            - test-deployment:
+                service-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
+                cluster-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
+
+      - aws-ecs/deploy-service-update:
           name: codedeploy_fargate_test-update-service-job
           docker-image-for-job: circleci/python:3.4.9
           requires:
@@ -666,7 +685,7 @@ workflows:
       - tear-down-test-env:
           name: fargate_tear-down-test-env
           requires:
-            - fargate_test-update-service-job
+            - fargate_test-update-service-skip-registration
           aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
           terraform-config-dir: "tests/terraform_setup/fargate"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -635,14 +635,10 @@ workflows:
           family: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
           cluster-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
           # test skipping registration of a new task definition
-          skip-task-definition-registration: false
+          skip-task-definition-registration: true
           verify-revision-is-deployed: true
           max-poll-attempts: 40
           poll-interval: 10
-          post-steps:
-            - test-deployment:
-                service-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
-                cluster-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
 
       - aws-ecs/deploy-service-update:
           name: codedeploy_fargate_test-update-service-job

--- a/dev-docs/README.md
+++ b/dev-docs/README.md
@@ -12,14 +12,73 @@ The following [project environment variables](https://circleci.com/docs/2.0/env-
 | -------------------------------| --------------------------------------|
 | `AWS_ACCESS_KEY_ID`            | Picked up by the AWS CLI              |
 | `AWS_SECRET_ACCESS_KEY`        | Picked up by the AWS CLI              |
-| `AWS_DEFAULT_REGION`           | Picked up by the AWS CLI              |
+| `AWS_DEFAULT_REGION`           | Picked up by the AWS CLI. Set to `us-east-1`.              |
 | `AWS_ACCOUNT_ID`               | AWS account id                        |
 | `CIRCLECI_API_KEY`             | Used by the `queue` orb               |
-| `AWS_RESOURCE_NAME_PREFIX_EC2` | Prefix used to name AWS resources for EC2 launch type integration tests                                        |
-| `AWS_RESOURCE_NAME_PREFIX_FARGATE` | Prefix used to name AWS resources for Fargate launch type integration tests                               |
-| `AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE` | Prefix used to name AWS resources for Fargate launch type integration tests that use CodeDeploy |
+| `AWS_RESOURCE_NAME_PREFIX_EC2` | Prefix used to name AWS resources for EC2 launch type integration tests. Set to `ecs-orb-ec2-1`.                                        |
+| `AWS_RESOURCE_NAME_PREFIX_FARGATE` | Prefix used to name AWS resources for Fargate launch type integration tests. Set to `ecs-orb-fg-1`.                               |
+| `AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE` | Prefix used to name AWS resources for Fargate launch type integration tests that use CodeDeploy. Set to `ecs-orb-cdfg-1`. |
 | `SKIP_TEST_ENV_CREATION`       | Whether to skip test env setup        |
 | `SKIP_TEST_ENV_TEARDOWN`       | Whether to skip test env teardown     |
+
+## Setting up / tearing down test infra locally
+
+You can also set up the same test infrastructure set up by the build pipeline,
+by running terraform locally.
+
+This is also useful when you need to tear down infra manually after the pipeline failed. (For the ec2 and fargate tests, you can also tear down the infrastructure by going to the CloudFormation page on the AWS console and deleting the stacks prefixed with `ecs-orb`)
+
+Set up AWS credentials and `AWS_DEFAULT_REGION`:
+
+```
+AWS_ACCESS_KEY_ID=...
+AWS_SECRET_ACCESS_KEY=...
+AWS_ACCOUNT_ID=...
+AWS_DEFAULT_REGION=us-east-1
+```
+
+Then set `AWS_RESOURCE_PREFIX` to the correct value:
+
+*For EC2 tests*
+
+```
+AWS_RESOURCE_PREFIX=ecs-orb-ec2-1
+cd tests/terraform_setup/ec2
+```
+
+*For Fargate tests*
+
+```
+AWS_RESOURCE_PREFIX=ecs-orb-fg-1
+cd tests/terraform_setup/fargate
+```
+
+*For CodeDeploy tests*
+
+```
+AWS_RESOURCE_PREFIX=ecs-orb-cdfg-1
+cd tests/terraform_setup/fargate_codedeploy
+```
+
+### Infra setup/teardown steps (for all)
+
+```
+terraform apply \
+    -var "aws_access_key=${AWS_ACCESS_KEY_ID}" \
+    -var "aws_secret_key=${AWS_SECRET_ACCESS_KEY}" \
+    -var "aws_region=${AWS_DEFAULT_REGION}" \
+    -var "aws_account_id=${AWS_ACCOUNT_ID}" \
+    -var "aws_resource_prefix=${AWS_RESOURCE_PREFIX}"
+```
+
+```
+terraform destroy \
+    -var "aws_access_key=${AWS_ACCESS_KEY_ID}" \
+    -var "aws_secret_key=${AWS_SECRET_ACCESS_KEY}" \
+    -var "aws_region=${AWS_DEFAULT_REGION}" \
+    -var "aws_account_id=${AWS_ACCOUNT_ID}" \
+    -var "aws_resource_prefix=${AWS_RESOURCE_PREFIX}"
+```
 
 ### Required Context and Context Environment Variables
 

--- a/src/orb.yml.hbs
+++ b/src/orb.yml.hbs
@@ -856,43 +856,43 @@ commands:
         default: false
     steps:
       - when:
-        condition: <<parameters.run-update-task-definition>>
-        steps:
-          - update-task-definition:
-            family: << parameters.family >>
-            container-image-name-updates: << parameters.container-image-name-updates >>
-            container-env-var-updates: << parameters.container-env-var-updates >>
-          - run:
-            name: Update service with registered task definition
-            command: |
-              DEPLOYMENT_CONTROLLER="$(echo << parameters.deployment-controller >>)"
+          condition: <<parameters.run-update-task-definition>>
+          steps:
+            - update-task-definition:
+                family: << parameters.family >>
+                container-image-name-updates: << parameters.container-image-name-updates >>
+                container-env-var-updates: << parameters.container-env-var-updates >>
+            - run:
+                name: Update service with registered task definition
+                command: |
+                  DEPLOYMENT_CONTROLLER="$(echo << parameters.deployment-controller >>)"
 
-              if [ "${DEPLOYMENT_CONTROLLER}" = "CODE_DEPLOY" ]; then
-                  DEPLOYED_REVISION="${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN}"
-                  DEPLOYMENT_ID=$(aws deploy create-deployment \
-                      --application-name "<< parameters.codedeploy-application-name >>" \
-                      --deployment-group-name "<< parameters.codedeploy-deployment-group-name >>" \
-                      --revision "{\"revisionType\": \"AppSpecContent\", \"appSpecContent\": {\"content\": \"{\\\"version\\\": 1, \\\"Resources\\\": [{\\\"TargetService\\\": {\\\"Type\\\": \\\"AWS::ECS::Service\\\", \\\"Properties\\\": {\\\"TaskDefinition\\\": \\\"${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN}\\\", \\\"LoadBalancerInfo\\\": {\\\"ContainerName\\\": \\\"<< parameters.codedeploy-load-balanced-container-name >>\\\", \\\"ContainerPort\\\": << parameters.codedeploy-load-balanced-container-port >>}}}}]}\"}}" \
-                      --query deploymentId)
-                  echo "Created CodeDeploy deployment: $DEPLOYMENT_ID"
-              else
-                SERVICE_NAME="$(echo << parameters.service-name >>)"
+                  if [ "${DEPLOYMENT_CONTROLLER}" = "CODE_DEPLOY" ]; then
+                      DEPLOYED_REVISION="${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN}"
+                      DEPLOYMENT_ID=$(aws deploy create-deployment \
+                          --application-name "<< parameters.codedeploy-application-name >>" \
+                          --deployment-group-name "<< parameters.codedeploy-deployment-group-name >>" \
+                          --revision "{\"revisionType\": \"AppSpecContent\", \"appSpecContent\": {\"content\": \"{\\\"version\\\": 1, \\\"Resources\\\": [{\\\"TargetService\\\": {\\\"Type\\\": \\\"AWS::ECS::Service\\\", \\\"Properties\\\": {\\\"TaskDefinition\\\": \\\"${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN}\\\", \\\"LoadBalancerInfo\\\": {\\\"ContainerName\\\": \\\"<< parameters.codedeploy-load-balanced-container-name >>\\\", \\\"ContainerPort\\\": << parameters.codedeploy-load-balanced-container-port >>}}}}]}\"}}" \
+                          --query deploymentId)
+                      echo "Created CodeDeploy deployment: $DEPLOYMENT_ID"
+                  else
+                    SERVICE_NAME="$(echo << parameters.service-name >>)"
 
-                if [ -z "${SERVICE_NAME}" ]; then
-                    SERVICE_NAME="$(echo << parameters.family >>)"
-                fi
-                if [ "<< parameters.force-new-deployment >>" == "true" ]; then
-                    set -- "$@" --force-new-deployment
-                fi
-                DEPLOYED_REVISION=$(aws ecs update-service \
-                    --cluster "<< parameters.cluster-name >>" \
-                    --service "${SERVICE_NAME}" \
-                    --task-definition "${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN}" \
-                    --output text \
-                    --query service.taskDefinition \
-                    "$@")
-              fi
-              echo "export CCI_ORB_AWS_ECS_DEPLOYED_REVISION='${DEPLOYED_REVISION}'" >> $BASH_ENV
+                    if [ -z "${SERVICE_NAME}" ]; then
+                        SERVICE_NAME="$(echo << parameters.family >>)"
+                    fi
+                    if [ "<< parameters.force-new-deployment >>" == "true" ]; then
+                        set -- "$@" --force-new-deployment
+                    fi
+                    DEPLOYED_REVISION=$(aws ecs update-service \
+                        --cluster "<< parameters.cluster-name >>" \
+                        --service "${SERVICE_NAME}" \
+                        --task-definition "${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN}" \
+                        --output text \
+                        --query service.taskDefinition \
+                        "$@")
+                  fi
+                  echo "export CCI_ORB_AWS_ECS_DEPLOYED_REVISION='${DEPLOYED_REVISION}'" >> $BASH_ENV
       - when:
           condition: << parameters.verify-revision-is-deployed >>
           steps:

--- a/src/orb.yml.hbs
+++ b/src/orb.yml.hbs
@@ -948,6 +948,9 @@ commands:
                 family: << parameters.family >>
                 container-image-name-updates: << parameters.container-image-name-updates >>
                 container-env-var-updates: << parameters.container-env-var-updates >>
+      - when:
+          condition: << parameters.skip-task-definition-registration >>
+          steps:
             - run:
                 name: Retrieve previous task definition
                 command: |
@@ -956,37 +959,37 @@ commands:
                     --output text \
                     --query 'taskDefinition.taskDefinitionArn')
                   echo "export CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN='${TASK_DEFINITION_ARN}'" >> $BASH_ENV
-            - run:
-                name: Update service with registered task definition
-                command: |
-                  DEPLOYMENT_CONTROLLER="$(echo << parameters.deployment-controller >>)"
+      - run:
+          name: Update service with registered task definition
+          command: |
+            DEPLOYMENT_CONTROLLER="$(echo << parameters.deployment-controller >>)"
 
-                  if [ "${DEPLOYMENT_CONTROLLER}" = "CODE_DEPLOY" ]; then
-                      DEPLOYED_REVISION="${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN}"
-                      DEPLOYMENT_ID=$(aws deploy create-deployment \
-                          --application-name "<< parameters.codedeploy-application-name >>" \
-                          --deployment-group-name "<< parameters.codedeploy-deployment-group-name >>" \
-                          --revision "{\"revisionType\": \"AppSpecContent\", \"appSpecContent\": {\"content\": \"{\\\"version\\\": 1, \\\"Resources\\\": [{\\\"TargetService\\\": {\\\"Type\\\": \\\"AWS::ECS::Service\\\", \\\"Properties\\\": {\\\"TaskDefinition\\\": \\\"${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN}\\\", \\\"LoadBalancerInfo\\\": {\\\"ContainerName\\\": \\\"<< parameters.codedeploy-load-balanced-container-name >>\\\", \\\"ContainerPort\\\": << parameters.codedeploy-load-balanced-container-port >>}}}}]}\"}}" \
-                          --query deploymentId)
-                      echo "Created CodeDeploy deployment: $DEPLOYMENT_ID"
-                  else
-                    SERVICE_NAME="$(echo << parameters.service-name >>)"
+            if [ "${DEPLOYMENT_CONTROLLER}" = "CODE_DEPLOY" ]; then
+                DEPLOYED_REVISION="${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN}"
+                DEPLOYMENT_ID=$(aws deploy create-deployment \
+                    --application-name "<< parameters.codedeploy-application-name >>" \
+                    --deployment-group-name "<< parameters.codedeploy-deployment-group-name >>" \
+                    --revision "{\"revisionType\": \"AppSpecContent\", \"appSpecContent\": {\"content\": \"{\\\"version\\\": 1, \\\"Resources\\\": [{\\\"TargetService\\\": {\\\"Type\\\": \\\"AWS::ECS::Service\\\", \\\"Properties\\\": {\\\"TaskDefinition\\\": \\\"${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN}\\\", \\\"LoadBalancerInfo\\\": {\\\"ContainerName\\\": \\\"<< parameters.codedeploy-load-balanced-container-name >>\\\", \\\"ContainerPort\\\": << parameters.codedeploy-load-balanced-container-port >>}}}}]}\"}}" \
+                    --query deploymentId)
+                echo "Created CodeDeploy deployment: $DEPLOYMENT_ID"
+            else
+              SERVICE_NAME="$(echo << parameters.service-name >>)"
 
-                    if [ -z "${SERVICE_NAME}" ]; then
-                        SERVICE_NAME="$(echo << parameters.family >>)"
-                    fi
-                    if [ "<< parameters.force-new-deployment >>" == "true" ]; then
-                        set -- "$@" --force-new-deployment
-                    fi
-                    DEPLOYED_REVISION=$(aws ecs update-service \
-                        --cluster "<< parameters.cluster-name >>" \
-                        --service "${SERVICE_NAME}" \
-                        --task-definition "${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN}" \
-                        --output text \
-                        --query service.taskDefinition \
-                        "$@")
-                  fi
-                  echo "export CCI_ORB_AWS_ECS_DEPLOYED_REVISION='${DEPLOYED_REVISION}'" >> $BASH_ENV
+              if [ -z "${SERVICE_NAME}" ]; then
+                  SERVICE_NAME="$(echo << parameters.family >>)"
+              fi
+              if [ "<< parameters.force-new-deployment >>" == "true" ]; then
+                  set -- "$@" --force-new-deployment
+              fi
+              DEPLOYED_REVISION=$(aws ecs update-service \
+                  --cluster "<< parameters.cluster-name >>" \
+                  --service "${SERVICE_NAME}" \
+                  --task-definition "${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN}" \
+                  --output text \
+                  --query service.taskDefinition \
+                  "$@")
+            fi
+            echo "export CCI_ORB_AWS_ECS_DEPLOYED_REVISION='${DEPLOYED_REVISION}'" >> $BASH_ENV
       - when:
           condition: << parameters.verify-revision-is-deployed >>
           steps:

--- a/src/orb.yml.hbs
+++ b/src/orb.yml.hbs
@@ -848,42 +848,51 @@ commands:
           Only in use when verify-revision-is-deployed is set to true.
         type: boolean
         default: true
+      run-update-task-definition:
+        description: |
+          Whether to run the update-task-definition again in the update-service or
+          not. Defaults to false and will only run when parameter is set to true.
+        type: boolean
+        default: false
     steps:
-      - update-task-definition:
-          family: << parameters.family >>
-          container-image-name-updates: << parameters.container-image-name-updates >>
-          container-env-var-updates: << parameters.container-env-var-updates >>
-      - run:
-          name: Update service with registered task definition
-          command: |
-            DEPLOYMENT_CONTROLLER="$(echo << parameters.deployment-controller >>)"
+      - when:
+        condition: <<parameters.run-update-task-definition>>
+        steps:
+          - update-task-definition:
+            family: << parameters.family >>
+            container-image-name-updates: << parameters.container-image-name-updates >>
+            container-env-var-updates: << parameters.container-env-var-updates >>
+          - run:
+            name: Update service with registered task definition
+            command: |
+              DEPLOYMENT_CONTROLLER="$(echo << parameters.deployment-controller >>)"
 
-            if [ "${DEPLOYMENT_CONTROLLER}" = "CODE_DEPLOY" ]; then
-                DEPLOYED_REVISION="${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN}"
-                DEPLOYMENT_ID=$(aws deploy create-deployment \
-                    --application-name "<< parameters.codedeploy-application-name >>" \
-                    --deployment-group-name "<< parameters.codedeploy-deployment-group-name >>" \
-                    --revision "{\"revisionType\": \"AppSpecContent\", \"appSpecContent\": {\"content\": \"{\\\"version\\\": 1, \\\"Resources\\\": [{\\\"TargetService\\\": {\\\"Type\\\": \\\"AWS::ECS::Service\\\", \\\"Properties\\\": {\\\"TaskDefinition\\\": \\\"${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN}\\\", \\\"LoadBalancerInfo\\\": {\\\"ContainerName\\\": \\\"<< parameters.codedeploy-load-balanced-container-name >>\\\", \\\"ContainerPort\\\": << parameters.codedeploy-load-balanced-container-port >>}}}}]}\"}}" \
-                    --query deploymentId)
-                echo "Created CodeDeploy deployment: $DEPLOYMENT_ID"
-            else
-              SERVICE_NAME="$(echo << parameters.service-name >>)"
+              if [ "${DEPLOYMENT_CONTROLLER}" = "CODE_DEPLOY" ]; then
+                  DEPLOYED_REVISION="${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN}"
+                  DEPLOYMENT_ID=$(aws deploy create-deployment \
+                      --application-name "<< parameters.codedeploy-application-name >>" \
+                      --deployment-group-name "<< parameters.codedeploy-deployment-group-name >>" \
+                      --revision "{\"revisionType\": \"AppSpecContent\", \"appSpecContent\": {\"content\": \"{\\\"version\\\": 1, \\\"Resources\\\": [{\\\"TargetService\\\": {\\\"Type\\\": \\\"AWS::ECS::Service\\\", \\\"Properties\\\": {\\\"TaskDefinition\\\": \\\"${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN}\\\", \\\"LoadBalancerInfo\\\": {\\\"ContainerName\\\": \\\"<< parameters.codedeploy-load-balanced-container-name >>\\\", \\\"ContainerPort\\\": << parameters.codedeploy-load-balanced-container-port >>}}}}]}\"}}" \
+                      --query deploymentId)
+                  echo "Created CodeDeploy deployment: $DEPLOYMENT_ID"
+              else
+                SERVICE_NAME="$(echo << parameters.service-name >>)"
 
-              if [ -z "${SERVICE_NAME}" ]; then
-                  SERVICE_NAME="$(echo << parameters.family >>)"
+                if [ -z "${SERVICE_NAME}" ]; then
+                    SERVICE_NAME="$(echo << parameters.family >>)"
+                fi
+                if [ "<< parameters.force-new-deployment >>" == "true" ]; then
+                    set -- "$@" --force-new-deployment
+                fi
+                DEPLOYED_REVISION=$(aws ecs update-service \
+                    --cluster "<< parameters.cluster-name >>" \
+                    --service "${SERVICE_NAME}" \
+                    --task-definition "${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN}" \
+                    --output text \
+                    --query service.taskDefinition \
+                    "$@")
               fi
-              if [ "<< parameters.force-new-deployment >>" == "true" ]; then
-                  set -- "$@" --force-new-deployment
-              fi
-              DEPLOYED_REVISION=$(aws ecs update-service \
-                  --cluster "<< parameters.cluster-name >>" \
-                  --service "${SERVICE_NAME}" \
-                  --task-definition "${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN}" \
-                  --output text \
-                  --query service.taskDefinition \
-                  "$@")
-            fi
-            echo "export CCI_ORB_AWS_ECS_DEPLOYED_REVISION='${DEPLOYED_REVISION}'" >> $BASH_ENV
+              echo "export CCI_ORB_AWS_ECS_DEPLOYED_REVISION='${DEPLOYED_REVISION}'" >> $BASH_ENV
       - when:
           condition: << parameters.verify-revision-is-deployed >>
           steps:

--- a/src/orb.yml.hbs
+++ b/src/orb.yml.hbs
@@ -273,6 +273,11 @@ jobs:
           Only in use when verify-revision-is-deployed is set to true.
         type: boolean
         default: true
+      skip-task-definition-registration:
+        description: |
+          Whether to skip registration of a new task definition.
+        type: boolean
+        default: false
     steps:
       - aws-cli/install
       - aws-cli/configure:
@@ -295,6 +300,7 @@ jobs:
           max-poll-attempts: << parameters.max-poll-attempts >>
           poll-interval: << parameters.poll-interval >>
           fail-on-verification-timeout: << parameters.fail-on-verification-timeout >>
+          skip-task-definition-registration: << parameters.skip-task-definition-registration >>
   update-task-definition:
     docker:
       - image: << parameters.docker-image-for-job >>
@@ -861,6 +867,14 @@ commands:
                 family: << parameters.family >>
                 container-image-name-updates: << parameters.container-image-name-updates >>
                 container-env-var-updates: << parameters.container-env-var-updates >>
+            - run:
+                name: Retrieve previous task definition
+                command: |
+                  TASK_DEFINITION_ARN=$(aws ecs describe-task-definition \
+                    --task-definition << parameters.family >> \
+                    --output text \
+                    --query 'taskDefinition.taskDefinitionArn')
+                  echo "export CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN='${TASK_DEFINITION_ARN}'" >> $BASH_ENV
             - run:
                 name: Update service with registered task definition
                 command: |

--- a/src/orb.yml.hbs
+++ b/src/orb.yml.hbs
@@ -848,15 +848,14 @@ commands:
           Only in use when verify-revision-is-deployed is set to true.
         type: boolean
         default: true
-      run-update-task-definition:
+      skip-task-definition-registration:
         description: |
-          Whether to run the update-task-definition again in the update-service or
-          not. Defaults to false and will only run when parameter is set to true.
+          Whether to skip registration of a new task definition.
         type: boolean
         default: false
     steps:
-      - when:
-          condition: <<parameters.run-update-task-definition>>
+      - unless:
+          condition: << parameters.skip-task-definition-registration >>
           steps:
             - update-task-definition:
                 family: << parameters.family >>

--- a/src/orb.yml.hbs
+++ b/src/orb.yml.hbs
@@ -962,6 +962,7 @@ commands:
       - run:
           name: Update service with registered task definition
           command: |
+            set -o noglob
             DEPLOYMENT_CONTROLLER="$(echo << parameters.deployment-controller >>)"
 
             if [ "${DEPLOYMENT_CONTROLLER}" = "CODE_DEPLOY" ]; then


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

This PR solves issue #85 to make the task `update-task-definition` optional since it is already run before.

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description

Add parameter `run-update-task-definition` to `update-service`.
Run update-task-definition only when `run-update-task-definition` parameter is set to true, defaults to false.
<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
