### PR TITLE
Prevent asterisk expansion when asterisk is present in task definition value [semver:patch]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -413,6 +413,10 @@ commands:
       cluster-name:
           description: "Name of the cluster"
           type: string
+      test-asterisk-expansion:
+          description: "Checks that asterisk expansion is prevented"
+          type: boolean
+          default: false
       delete-load-balancer:
           description: "Whether to delete the load balancer after the test"
           type: boolean
@@ -426,7 +430,8 @@ commands:
             ELB_ARN=$(aws elbv2 describe-target-groups --target-group-arns $TARGET_GROUP_ARN | jq -r '.TargetGroups[0].LoadBalancerArns[0]')
             ELB_DNS_NAME=$(aws elbv2 describe-load-balancers --load-balancer-arns $ELB_ARN | jq -r '.LoadBalancers[0].DNSName')
             for attempt in {1..25}; do
-              curl -s --retry 10 http://$ELB_DNS_NAME | grep -E "Hello World!.*${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}"
+              curl -s --retry 10 http://$ELB_DNS_NAME \
+                | grep -E "Hello World!.*${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}" <<#parameters.test-asterisk-expansion>> | grep "Asterisk \* expansion test"<</parameters.test-asterisk-expansion>>
             done
             if [ "<< parameters.delete-load-balancer >>" == "true" ]; then
               aws elbv2 delete-load-balancer --load-balancer-arn $ELB_ARN
@@ -558,13 +563,14 @@ workflows:
           family: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
           service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
           cluster-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
-          container-env-var-updates: "container=${AWS_RESOURCE_NAME_PREFIX_EC2}-service,name=VERSION_INFO,value=\"${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}\",container=${AWS_RESOURCE_NAME_PREFIX_EC2}-service,name=BUILD_DATE,value=$(date)"
+          container-env-var-updates: "container=${AWS_RESOURCE_NAME_PREFIX_EC2}-service,name=VERSION_INFO,value=\"Asterisk * expansion test ${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}\",container=${AWS_RESOURCE_NAME_PREFIX_EC2}-service,name=BUILD_DATE,value=$(date)"
           verify-revision-is-deployed: true
           fail-on-verification-timeout: false
           post-steps:
             - test-deployment:
                 service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
                 cluster-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
+                test-asterisk-expansion: true
 
       - aws-ecs/deploy-service-update:
           name: fargate_test-update-service-job

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog
 Documents changes in orb version releases.
 
+## [[1.0.5](https://circleci.com/orbs/registry/orb/circleci/aws-ecs?version=1.0.5)]
+### Fixed
+- Prevent asterisk expansion when asterisk is present in task definition value [\#90](https://github.com/CircleCI-Public/aws-ecs-orb/pull/90) ([lokst](https://github.com/lokst))
+
+## [[1.0.4](https://circleci.com/orbs/registry/orb/circleci/aws-ecs?version=1.0.4)]
+### Changed
+- Enhancement: Add overrides parameter to run-task job and command [\#84](https://github.com/CircleCI-Public/aws-ecs-orb/pull/84) ([lokst](https://github.com/lokst))
+
+## [[1.0.3](https://circleci.com/orbs/registry/orb/circleci/aws-ecs?version=1.0.3)]
+### Changed
+- Enhancement: Support --force-new-deployment [\#83](https://github.com/CircleCI-Public/aws-ecs-orb/pull/83) ([lokst](https://github.com/lokst))
+
 ## [[1.0.2](https://circleci.com/orbs/registry/orb/circleci/aws-ecs?version=1.0.2)]
 ### Changed
 - Updated example to use more recent version of circleci/aws-ecr orb [\#81](https://github.com/CircleCI-Public/aws-ecs-orb/pull/81) ([uraway](https://github.com/uraway))

--- a/src/orb.yml.hbs
+++ b/src/orb.yml.hbs
@@ -641,6 +641,7 @@ commands:
       - run:
           name: Retrieve previous task definition and prepare new task definition values
           command: |
+            set -o noglob
             PREVIOUS_TASK_DEFINITION=$(aws ecs describe-task-definition --task-definition << parameters.family >> --include TAGS)
             CONTAINER_IMAGE_NAME_UPDATES="$(echo << parameters.container-image-name-updates >>)"
             CONTAINER_ENV_VAR_UPDATES="$(echo << parameters.container-env-var-updates >>)"
@@ -655,9 +656,9 @@ commands:
 
             # Prepare container definitions
             CONTAINER_DEFS=$(python $UPDATE_CONTAINER_DEFS_SCRIPT_FILE "$PREVIOUS_TASK_DEFINITION" "$CONTAINER_IMAGE_NAME_UPDATES" "$CONTAINER_ENV_VAR_UPDATES")
-            
+
             # Escape single quotes from environment variables for BASH_ENV
-            CLEANED_CONTAINER_DEFS=$(echo $CONTAINER_DEFS | sed -E "s:':'\\\'':g")
+            CLEANED_CONTAINER_DEFS=$(echo "$CONTAINER_DEFS" | sed -E "s:':'\\\'':g")
 
             # Prepare script for getting task definition values
             GET_TASK_DFN_VAL_SCRIPT_FILE=$(mktemp _get_task_def_value.py.XXXXXX)
@@ -700,6 +701,7 @@ commands:
       - run:
           name: Register new task definition
           command: |
+            set -o noglob
             if [ -n "${CCI_ORB_AWS_ECS_TASK_ROLE}" ]; then
                 set -- "$@" --task-role-arn "${CCI_ORB_AWS_ECS_TASK_ROLE}"
             fi
@@ -856,6 +858,7 @@ commands:
       - run:
           name: Update service with registered task definition
           command: |
+            set -o noglob
             DEPLOYMENT_CONTROLLER="$(echo << parameters.deployment-controller >>)"
 
             if [ "${DEPLOYMENT_CONTROLLER}" = "CODE_DEPLOY" ]; then
@@ -1021,6 +1024,7 @@ commands:
       - run:
           name: Run Task
           command: |
+            set -o noglob
             if [ "<<parameters.launch-type>>" == "FARGATE" ]; then
                 echo "Setting --platform-version"
                 set -- "$@" --platform-version "<<parameters.platform-version>>"


### PR DESCRIPTION
This is a fix for https://github.com/CircleCI-Public/aws-ecs-orb/issues/89.
"set -o noglob" is used to prevent unwanted expansion of asterisks present in task definitions, by the shell.
`.circleci/config.yml` has also been updated so that the integration tests include a test for the fix.

Sample test: https://circleci.com/gh/CircleCI-Public/aws-ecs-orb/2620