### PR TITLE
Add command support for --cli-input-json

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -245,6 +245,33 @@ jobs:
                 service-name: "<< parameters.aws-resource-name-prefix >>-service"
                 cluster-name: "<< parameters.aws-resource-name-prefix >>-cluster"
 
+  test-task-definition-update:
+    docker:
+      - image: circleci/python:3.7.1
+    parameters:
+      family-name:
+        description: "Family name"
+        type: string
+    steps:
+      - checkout
+      - aws-cli/install
+      - aws-cli/configure:
+          aws-access-key-id: "$AWS_ACCESS_KEY_ID"
+          aws-region: "$AWS_DEFAULT_REGION"
+      - run:
+          name: Get existing task definition
+          command: |
+            aws ecs describe-task-definition --task-definition << parameters.family-name >> \
+              | jq '.taskDefinition' | jq '.memory = "3072"' \
+              | jq 'del(.["taskDefinitionArn", "revision", "status", "requiresAttributes", "compatibilities"])' \
+              > task-definition.json
+      - aws-ecs/update-task-definition-from-json:
+          task-definition-json: "task-definition.json"
+      - run:
+          name: Check if task definition was updated
+          command: |
+            aws ecs describe-task-definition --task-definition << parameters.family-name >> --include TAGS | grep "3072"
+
   set-up-run-task-test:
     docker:
       - image: circleci/python:3.7.1
@@ -553,11 +580,17 @@ workflows:
           docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
           skip-service-update: true
 
+      - test-task-definition-update:
+          name: ec2_test-task-definition-update
+          family-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
+          requires:
+            - ec2_test-update-service-command
+
       - aws-ecs/deploy-service-update:
           name: ec2_test-update-service-job
           docker-image-for-job: circleci/python:2.7.15
           requires:
-            - ec2_test-update-service-command
+            - ec2_test-task-definition-update
           aws-access-key-id: "${AWS_ACCESS_KEY_ID}"
           aws-region: "${AWS_DEFAULT_REGION}"
           family: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"

--- a/src/orb.yml.hbs
+++ b/src/orb.yml.hbs
@@ -352,6 +352,42 @@ jobs:
           family: << parameters.family >>
           container-image-name-updates: << parameters.container-image-name-updates >>
           container-env-var-updates: << parameters.container-env-var-updates >>
+  update-task-definition-from-json:
+    docker:
+      - image: << parameters.docker-image-for-job >>
+    parameters:
+      docker-image-for-job:
+        description:
+          "The docker image to be used for running this job on CircleCI."
+        type: string
+        default: circleci/python:3.7.1
+      aws-access-key-id:
+        description: |
+          AWS access key id for IAM role. Defaulted to $AWS_ACCESS_KEY_ID
+        type: string
+        default: $AWS_ACCESS_KEY_ID
+      aws-secret-access-key:
+        description: |
+          AWS secret key for IAM role. Defaulted to $AWS_SECRET_ACCESS_KEY
+        type: string
+        default: $AWS_SECRET_ACCESS_KEY
+      aws-region:
+        description:
+          AWS region to operate in. Defaulted to $AWS_REGION
+        type: string
+        default: $AWS_REGION
+      task-definition-json:
+        description: |
+          Location of your .json task definition file (relative or absolute).
+        type: string
+    steps:
+      - aws-cli/install
+      - aws-cli/configure:
+          aws-access-key-id: << parameters.aws-access-key-id >>
+          aws-secret-access-key: << parameters.aws-secret-access-key >>
+          aws-region: << parameters.aws-region >>
+      - update-task-definition-from-json:
+          task-definition-json: << parameters.task-definition-json >>
   run-task:
     docker:
       - image: << parameters.docker-image-for-job >>

--- a/src/orb.yml.hbs
+++ b/src/orb.yml.hbs
@@ -746,6 +746,47 @@ commands:
                 --query 'taskDefinition.taskDefinitionArn')
             echo "Registered task definition: ${REVISION}"
             echo "export CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN='${REVISION}'" >> $BASH_ENV
+  update-task-definition-cli-input-json:
+    description: Registers a task definition based on a json file.
+    parameters:
+      task-definition-json:
+        description: |
+          Location of your .json task definition file.
+        type: string
+      aws-access-key-id:
+        default: AWS_ACCESS_KEY_ID
+        description: >
+          AWS access key id for IAM role. Set this to the name of the environment
+          variable you will set to hold this value, i.e. AWS_ACCESS_KEY.
+        type: env_var_name
+      aws-secret-access-key:
+        default: AWS_SECRET_ACCESS_KEY
+        description: >
+          AWS secret key for IAM role. Set this to the name of the environment
+          variable you will set to hold this value, i.e. AWS_SECRET_ACCESS_KEY.
+        type: env_var_name
+      aws-region:
+        default: AWS_REGION
+        description:
+          Name of env var storing your AWS region information, defaults to AWS_REGION
+        type: env_var_name
+    steps:
+      - checkout
+      - aws-cli/install
+      - aws-cli/configure:
+          aws-access-key-id: $<< parameters.aws-access-key-id >>
+          aws-secret-access-key: $<< parameters.aws-secret-access-key >>
+          aws-region: $<< parameters.aws-region >>
+      - run:
+          name: Register new task definition
+          command: |
+            TASK_DEFINITION_JSON="$(echo << parameters.task-definition-json >>)"
+            REVISION=$(aws ecs register-task-definition \
+                --cli-input-json file://$(pwd)/${TASK_DEFINITION_JSON} \
+                --output text \
+                --query 'taskDefinition.taskDefinitionArn')
+            echo "Registered task definition: ${REVISION}"
+            echo "export CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN='${REVISION}'" >> $BASH_ENV
   update-service:
     description: |
       Registers a task definition for the given ECS service and updates the service to

--- a/src/orb.yml.hbs
+++ b/src/orb.yml.hbs
@@ -746,7 +746,7 @@ commands:
                 --query 'taskDefinition.taskDefinitionArn')
             echo "Registered task definition: ${REVISION}"
             echo "export CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN='${REVISION}'" >> $BASH_ENV
-  update-task-definition-cli-input-json:
+  update-task-definition-from-json:
     description: Registers a task definition based on a json file.
     parameters:
       task-definition-json:

--- a/src/orb.yml.hbs
+++ b/src/orb.yml.hbs
@@ -751,32 +751,9 @@ commands:
     parameters:
       task-definition-json:
         description: |
-          Location of your .json task definition file.
+          Location of your .json task definition file (relative or absolute).
         type: string
-      aws-access-key-id:
-        default: AWS_ACCESS_KEY_ID
-        description: >
-          AWS access key id for IAM role. Set this to the name of the environment
-          variable you will set to hold this value, i.e. AWS_ACCESS_KEY.
-        type: env_var_name
-      aws-secret-access-key:
-        default: AWS_SECRET_ACCESS_KEY
-        description: >
-          AWS secret key for IAM role. Set this to the name of the environment
-          variable you will set to hold this value, i.e. AWS_SECRET_ACCESS_KEY.
-        type: env_var_name
-      aws-region:
-        default: AWS_REGION
-        description:
-          Name of env var storing your AWS region information, defaults to AWS_REGION
-        type: env_var_name
     steps:
-      - checkout
-      - aws-cli/install
-      - aws-cli/configure:
-          aws-access-key-id: $<< parameters.aws-access-key-id >>
-          aws-secret-access-key: $<< parameters.aws-secret-access-key >>
-          aws-region: $<< parameters.aws-region >>
       - run:
           name: Register new task definition
           command: |

--- a/src/orb.yml.hbs
+++ b/src/orb.yml.hbs
@@ -35,6 +35,28 @@ examples:
                 cluster-name: "${MY_APP_PREFIX}-cluster"
                 container-image-name-updates: "container=${MY_APP_PREFIX}-service,tag=${CIRCLE_SHA1}"
 
+  update-task-definition-from-json:
+    description: |
+      Use the AWS CLI and this orb to create a new ECS task definition
+      based upon a local JSON file.
+    usage:
+      version: 2.1
+
+      orbs:
+        aws-cli: circleci/aws-cli@0.1.4
+        aws-ecs: circleci/aws-ecs@1.0.5
+
+      jobs:
+        update-tag:
+          docker:
+            - image: circleci/python:3.7.1
+          steps:
+            - aws-cli/install
+            - aws-cli/configure:
+                aws-access-key-id: "$AWS_ACCESS_KEY_ID"
+                aws-region: "$AWS_REGION"
+            - aws-ecs/update-task-definition-from-json:
+                task-definition-json: "my-app-definition.json"
   update-service:
     description: |
       Use the AWS CLI and this orb to update an ECS service.

--- a/src/orb.yml.hbs
+++ b/src/orb.yml.hbs
@@ -781,8 +781,11 @@ commands:
           name: Register new task definition
           command: |
             TASK_DEFINITION_JSON="$(echo << parameters.task-definition-json >>)"
+            if [ "${TASK_DEFINITION_JSON:0:1}" != "/" ]; then
+                TASK_DEFINITION_JSON="$(pwd)/${TASK_DEFINITION_JSON}"
+            fi
             REVISION=$(aws ecs register-task-definition \
-                --cli-input-json file://$(pwd)/${TASK_DEFINITION_JSON} \
+                --cli-input-json file://${TASK_DEFINITION_JSON} \
                 --output text \
                 --query 'taskDefinition.taskDefinitionArn')
             echo "Registered task definition: ${REVISION}"


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

This PR addresses #20. I like having the ability to keep my task definitions in my source code and simply updating the task definition based upon that .json.

### Description

Add the ability to update task definitions based upon a stored `.json` file

This PR was initially https://github.com/CircleCI-Public/aws-ecs-orb/pull/47 but I screwed the rebase, so here we are....