### PR TITLE
Fix the run task integration test to tear down correct task definition

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -546,7 +546,7 @@ workflows:
           name: ec2_tear-down-run-task-test
           requires:
             - ec2_run-task-test
-          family-name: ecs-test-sleep360
+          family-name: ${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360
 
       # test ecs updates
       - test-service-update:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 Documents changes in orb version releases.
 
+## [[1.1.0](https://circleci.com/orbs/registry/orb/circleci/aws-ecs?version=1.1.0)]
+### Added
+- Enhancement: Add update-task-definition-from-json command and job [\#91](https://github.com/CircleCI-Public/aws-ecs-orb/pull/91) ([a10waveracer](https://github.com/a10waveracer))
+https://github.com/CircleCI-Public/aws-ecs-orb/pull/91
+
 ## [[1.0.5](https://circleci.com/orbs/registry/orb/circleci/aws-ecs?version=1.0.5)]
 ### Fixed
 - Prevent asterisk expansion when asterisk is present in task definition value [\#90](https://github.com/CircleCI-Public/aws-ecs-orb/pull/90) ([lokst](https://github.com/lokst))


### PR DESCRIPTION
Fixes the `ec2_tear-down-run-task-test` integration test job so that it tears down the task definition that was created by the integration tests (in an earlier job in the workflow), rather than an externally created one.

Example after fix: https://circleci.com/gh/CircleCI-Public/aws-ecs-orb/2737

Also updates the changelog so that it includes the most recent (unrelated to this PR) release.
