### PR TITLE
Code Deploy (Blue/Green) Verify Deployment Status.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -687,7 +687,7 @@ workflows:
           codedeploy-load-balanced-container-port: 8080
           verify-revision-is-deployed: true
           verification-timeout: "12m"
-          post_steps:
+          post-steps:
             - test-deployment:
                 service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
                 cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -670,7 +670,7 @@ workflows:
                 cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
 
       - aws-ecs/deploy-service-update:
-          name: codedeploy_fargate_test-update-service-job
+          name: codedeploy_fargate_test-update-and-wait-service-job
           docker-image-for-job: circleci/python:3.4.9
           requires:
             - codedeploy_fargate_test-update-service-command
@@ -714,6 +714,7 @@ workflows:
           name: codedeploy_fargate_tear-down-test-env
           requires:
             - codedeploy_fargate_test-update-service-job
+            - codedeploy_fargate_test-update-and-wait-service-job
           terraform-image: "hashicorp/terraform:0.12.16"
           aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
           terraform-config-dir: "tests/terraform_setup/fargate_codedeploy"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -673,7 +673,7 @@ workflows:
           name: codedeploy_fargate_test-update-and-wait-service-job
           docker-image-for-job: circleci/python:3.4.9
           requires:
-            - codedeploy_fargate_test-update-service-command
+            - codedeploy_fargate_test-update-service-job
           aws-access-key-id: "${AWS_ACCESS_KEY_ID}"
           aws-region: "${AWS_DEFAULT_REGION}"
           family: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
@@ -691,10 +691,6 @@ workflows:
                 service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
                 cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
                 delete-load-balancer: true
-            - delete-service:
-                service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-                cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
-
       - tear-down-test-env:
           name: ec2_tear-down-test-env
           requires:
@@ -713,7 +709,6 @@ workflows:
       - tear-down-test-env:
           name: codedeploy_fargate_tear-down-test-env
           requires:
-            - codedeploy_fargate_test-update-service-job
             - codedeploy_fargate_test-update-and-wait-service-job
           terraform-image: "hashicorp/terraform:0.12.16"
           aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -686,6 +686,7 @@ workflows:
           codedeploy-load-balanced-container-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
           codedeploy-load-balanced-container-port: 8080
           verify-revision-is-deployed: true
+          verification-timeout: "12m"
           post_steps:
             - test-deployment:
                 service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -656,7 +656,6 @@ workflows:
           codedeploy-deployment-group-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
           codedeploy-load-balanced-container-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
           codedeploy-load-balanced-container-port: 8080
-          # verify-revision-is-deployed is not supported for blue/green deployment type services
           verify-revision-is-deployed: false
           post-steps:
             - wait-for-codedeploy-deployment:
@@ -669,6 +668,24 @@ workflows:
             - delete-service:
                 service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
                 cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+
+      - aws-ecs/deploy-service-update:
+          name: codedeploy_fargate_test-update-service-job
+          docker-image-for-job: circleci/python:3.4.9
+          requires:
+            - codedeploy_fargate_test-update-service-command
+          aws-access-key-id: "${AWS_ACCESS_KEY_ID}"
+          aws-region: "${AWS_DEFAULT_REGION}"
+          family: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+          cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+          container-image-name-updates: "container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,image-and-tag=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
+          container-env-var-updates: "container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=VERSION_INFO,value=\"${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}\",container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=BUILD_DATE,value=$(date)"
+          deployment-controller: "CODE_DEPLOY"
+          codedeploy-application-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeployapp"
+          codedeploy-deployment-group-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
+          codedeploy-load-balanced-container-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+          codedeploy-load-balanced-container-port: 8080
+          verify-revision-is-deployed: true
 
       - tear-down-test-env:
           name: ec2_tear-down-test-env

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -664,10 +664,7 @@ workflows:
             - test-deployment:
                 service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
                 cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
-                delete-load-balancer: true
-            - delete-service:
-                service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-                cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+                delete-load-balancer: false
 
       - aws-ecs/deploy-service-update:
           name: codedeploy_fargate_test-update-and-wait-service-job
@@ -692,6 +689,9 @@ workflows:
                 service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
                 cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
                 delete-load-balancer: true
+            - delete-service:
+                service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+                cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
       - tear-down-test-env:
           name: ec2_tear-down-test-env
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -686,6 +686,14 @@ workflows:
           codedeploy-load-balanced-container-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
           codedeploy-load-balanced-container-port: 8080
           verify-revision-is-deployed: true
+          post_steps:
+            - test-deployment:
+                service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+                cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+                delete-load-balancer: true
+            - delete-service:
+                service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+                cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
 
       - tear-down-test-env:
           name: ec2_tear-down-test-env

--- a/src/orb.yml.hbs
+++ b/src/orb.yml.hbs
@@ -973,8 +973,7 @@ commands:
                   echo "export CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN='${TASK_DEFINITION_ARN}'" >> $BASH_ENV
       - when:
           condition: 
-            - not: 
-                equal: [ "ECS", << parameters.deployment-controller >> ]
+              - equal: [ "CODE_DEPLOY", << parameters.deployment-controller >> ]
           steps:
             - run:
                 name: Update ECS Blue/Green service with registered task definition.

--- a/src/orb.yml.hbs
+++ b/src/orb.yml.hbs
@@ -975,16 +975,16 @@ commands:
                   seconds=3600+$SECONDS
                   while (( $SECONDS < $seconds )); do
                     DEPLOYMENT_STATUS=$(aws deploy get-deployment --deployment-id $DEPLOYMENT_ID)  
-                    if grep "\"status\": \"Succeeded\"" <<< $DEPLOYMENT_STATUS; then
+                    if grep "\"status\": \"Succeeded\"" \<<< $DEPLOYMENT_STATUS; then
                       echo "Deployment Success" 
                       exit 0  
-                    elif grep "\"status\": \"Failed\"" <<< $DEPLOYMENT_STATUS; then 
+                    elif grep "\"status\": \"Failed\"" \<<< $DEPLOYMENT_STATUS; then 
                       echo "Deployment Failed"
                       exit 1 
-                    elif grep "\"status\": \"Stopped\"" <<< $DEPLOYMENT_STATUS; then 
+                    elif grep "\"status\": \"Stopped\"" \<<< $DEPLOYMENT_STATUS; then 
                       echo "Deployment Stopped"
                       exit 1 
-                    elif grep "\"status\": \"Skipped\"" <<< $DEPLOYMENT_STATUS; then 
+                    elif grep "\"status\": \"Skipped\"" \<<< $DEPLOYMENT_STATUS; then 
                       echo "Deployment Skipped"
                       exit 1 
                     else

--- a/src/orb.yml.hbs
+++ b/src/orb.yml.hbs
@@ -985,7 +985,8 @@ commands:
                       --application-name "<< parameters.codedeploy-application-name >>" \
                       --deployment-group-name "<< parameters.codedeploy-deployment-group-name >>" \
                       --revision "{\"revisionType\": \"AppSpecContent\", \"appSpecContent\": {\"content\": \"{\\\"version\\\": 1, \\\"Resources\\\": [{\\\"TargetService\\\": {\\\"Type\\\": \\\"AWS::ECS::Service\\\", \\\"Properties\\\": {\\\"TaskDefinition\\\": \\\"${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN}\\\", \\\"LoadBalancerInfo\\\": {\\\"ContainerName\\\": \\\"<< parameters.codedeploy-load-balanced-container-name >>\\\", \\\"ContainerPort\\\": << parameters.codedeploy-load-balanced-container-port >>}}}}]}\"}}" \
-                      --query deploymentId)
+                      --query deploymentId \
+                      --output text)
                   echo "Created CodeDeploy deployment: $DEPLOYMENT_ID"
                   if [ "<< parameters.verify-revision-is-deployed >>" == "true" ]; then
                     echo "Waiting for deployment to succeed."

--- a/src/orb.yml.hbs
+++ b/src/orb.yml.hbs
@@ -998,7 +998,10 @@ commands:
             fi
             echo "export CCI_ORB_AWS_ECS_DEPLOYED_REVISION='${DEPLOYED_REVISION}'" >> $BASH_ENV
       - when:
-          condition: << parameters.verify-revision-is-deployed >>
+          condition:
+            and:
+             - << parameters.verify-revision-is-deployed >>
+             - equal: [ ECS, << parameters.deployment-controller >> ]
           steps:
             - verify-revision-is-deployed:
                 family: << parameters.family >>

--- a/src/orb.yml.hbs
+++ b/src/orb.yml.hbs
@@ -974,7 +974,6 @@ commands:
                   seconds=3600+$SECONDS
                   while (( $SECONDS < $seconds )); do
                     DEPLOYMENT_STATUS=$(aws deploy get-deployment --deployment-id $DEPLOYMENT_ID)  
-                    echo $DEPLOYMENT_STATUS
                     if grep "\"status\": \"Succeeded\"" <<< $DEPLOYMENT_STATUS; then
                       echo "Deployment Success" 
                       exit 0  

--- a/src/orb.yml.hbs
+++ b/src/orb.yml.hbs
@@ -972,8 +972,8 @@ commands:
                     --query 'taskDefinition.taskDefinitionArn')
                   echo "export CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN='${TASK_DEFINITION_ARN}'" >> $BASH_ENV
       - when:
-          condition: 
-              - equal: [ "CODE_DEPLOY", << parameters.deployment-controller >> ]
+          condition:
+            equal: [ "CODE_DEPLOY", << parameters.deployment-controller >> ]
           steps:
             - run:
                 name: Update ECS Blue/Green service with registered task definition.
@@ -998,28 +998,28 @@ commands:
           no_output_timeout: << parameters.verification-timeout >> 
       - when:
           condition:
-            - equal: [ "ECS", << parameters.deployment-controller >> ] 
-          steps: 
+            equal: [ "ECS", << parameters.deployment-controller >> ]
+          steps:
             - run:
-              name: Update service with registered task definition
-              command: |
-                set -o noglob
-                SERVICE_NAME="$(echo << parameters.service-name >>)"
+                name: Update service with registered task definition
+                command: |
+                  set -o noglob
+                  SERVICE_NAME="$(echo << parameters.service-name >>)"
 
-                if [ -z "${SERVICE_NAME}" ]; then
-                    SERVICE_NAME="$(echo << parameters.family >>)"
-                fi
-                if [ "<< parameters.force-new-deployment >>" == "true" ]; then
-                    set -- "$@" --force-new-deployment
-                fi
-                DEPLOYED_REVISION=$(aws ecs update-service \
-                    --cluster "<< parameters.cluster-name >>" \
-                    --service "${SERVICE_NAME}" \
-                    --task-definition "${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN}" \
-                    --output text \
-                    --query service.taskDefinition \
-                    "$@")
-                echo "export CCI_ORB_AWS_ECS_DEPLOYED_REVISION='${DEPLOYED_REVISION}'" >> $BASH_ENV
+                  if [ -z "${SERVICE_NAME}" ]; then
+                      SERVICE_NAME="$(echo << parameters.family >>)"
+                  fi
+                  if [ "<< parameters.force-new-deployment >>" == "true" ]; then
+                      set -- "$@" --force-new-deployment
+                  fi
+                  DEPLOYED_REVISION=$(aws ecs update-service \
+                      --cluster "<< parameters.cluster-name >>" \
+                      --service "${SERVICE_NAME}" \
+                      --task-definition "${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN}" \
+                      --output text \
+                      --query service.taskDefinition \
+                      "$@")
+                  echo "export CCI_ORB_AWS_ECS_DEPLOYED_REVISION='${DEPLOYED_REVISION}'" >> $BASH_ENV
       - when:
           condition:
             and:

--- a/src/orb.yml.hbs
+++ b/src/orb.yml.hbs
@@ -587,6 +587,7 @@ commands:
       Polls the service's deployment status at intervals until the given task
       definition revision is the only one deployed for the service, and for the
       task definition revision's running task count to match the desired count.
+      Does not support ECS services that are of the Blue/Green Deployment type.
     parameters:
       family:
         description:

--- a/src/orb.yml.hbs
+++ b/src/orb.yml.hbs
@@ -985,7 +985,7 @@ commands:
                       exit 1 
                     elif grep "\"status\": \"Skipped\"" <<< $DEPLOYMENT_STATUS; then 
                       echo "Deployment Skipped"
-                      exit 0 
+                      exit 1 
                     else
                       echo "Sleeping for 1 minute before retrying the status of the deployment" 
                       sleep 60s

--- a/src/orb.yml.hbs
+++ b/src/orb.yml.hbs
@@ -991,6 +991,8 @@ commands:
                       sleep 60s
                     fi
                   done
+                  echo "No response from Code deploy, exiting." 
+                  exit 1
                 fi
             else
               SERVICE_NAME="$(echo << parameters.service-name >>)"

--- a/src/orb.yml.hbs
+++ b/src/orb.yml.hbs
@@ -273,7 +273,6 @@ jobs:
           for the service. Note: enabling this may result in the build
           being marked as failed if tasks for older revisions fail to be stopped
           before the max number of polling attempts is reached.
-          Does not support ECS services that are of the Blue/Green Deployment type.
         type: boolean
         default: false
       max-poll-attempts:
@@ -588,7 +587,6 @@ commands:
       Polls the service's deployment status at intervals until the given task
       definition revision is the only one deployed for the service, and for the
       task definition revision's running task count to match the desired count.
-      Does not support ECS services that are of the Blue/Green Deployment type.
     parameters:
       family:
         description:
@@ -913,7 +911,6 @@ commands:
           for the service. Note: enabling this may result in the build
           being marked as failed if tasks for older revisions fail to be stopped
           before the max number of polling attempts is reached.
-          Does not support ECS services that are of the Blue/Green Deployment type.
         type: boolean
         default: false
       max-poll-attempts:

--- a/src/orb.yml.hbs
+++ b/src/orb.yml.hbs
@@ -973,6 +973,26 @@ commands:
                     --revision "{\"revisionType\": \"AppSpecContent\", \"appSpecContent\": {\"content\": \"{\\\"version\\\": 1, \\\"Resources\\\": [{\\\"TargetService\\\": {\\\"Type\\\": \\\"AWS::ECS::Service\\\", \\\"Properties\\\": {\\\"TaskDefinition\\\": \\\"${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN}\\\", \\\"LoadBalancerInfo\\\": {\\\"ContainerName\\\": \\\"<< parameters.codedeploy-load-balanced-container-name >>\\\", \\\"ContainerPort\\\": << parameters.codedeploy-load-balanced-container-port >>}}}}]}\"}}" \
                     --query deploymentId)
                 echo "Created CodeDeploy deployment: $DEPLOYMENT_ID"
+                if [ "<< parameters.verify-revision-is-deployed >>" == "true" ]; then
+                  seconds=3600+$SECONDS
+                  while (( $SECONDS < $seconds )); do
+                    DEPLOYMENT_STATUS=$(aws deploy get-deployment --deployment-id $DEPLOYMENT_ID)  
+                    echo $DEPLOYMENT_STATUS
+                    if grep "\"status\": \"Succeeded\"" <<< $DEPLOYMENT_STATUS; then
+                      echo "Deployment Success" 
+                      exit 0  
+                    elif grep "\"status\": \"Failed\"" <<< $DEPLOYMENT_STATUS; then 
+                      echo "Deployment Failed"
+                      exit 1 
+                    elif grep "\"status\": \"Stopped\"" <<< $DEPLOYMENT_STATUS; then 
+                      echo "Deployment Stopped"
+                      exit 1 
+                    else
+                      echo "Sleeping for 1 minute before retrying the status of the deployment" 
+                      sleep 60s
+                    fi
+                  done
+                fi
             else
               SERVICE_NAME="$(echo << parameters.service-name >>)"
 

--- a/src/orb.yml.hbs
+++ b/src/orb.yml.hbs
@@ -275,6 +275,12 @@ jobs:
           before the max number of polling attempts is reached.
         type: boolean
         default: false
+      verification-timeout:
+        description: |
+          The maximum amount of time to wait for a blue/green deployment to complete before timing out.
+          Only in use when the deployment controller is the blue/green deployment type.
+        type: string
+        default: "10m"
       max-poll-attempts:
         description: |
           The maximum number of attempts to poll the deployment status before giving up.
@@ -322,6 +328,7 @@ jobs:
           poll-interval: << parameters.poll-interval >>
           fail-on-verification-timeout: << parameters.fail-on-verification-timeout >>
           skip-task-definition-registration: << parameters.skip-task-definition-registration >>
+          verification-timeout: << parameters.verification-timeout >> 
   update-task-definition:
     docker:
       - image: << parameters.docker-image-for-job >>
@@ -672,6 +679,7 @@ commands:
             done
             echo "Stopped waiting for deployment to be stable - please check the status of << parameters.task-definition-arn >> on the AWS ECS console."
             <<# parameters.fail-on-verification-timeout >>exit 1<</ parameters.fail-on-verification-timeout >>
+
   update-task-definition:
     description: Registers a task definition based on the last task definition, except
       with the Docker image/tag names and environment variables of the containers
@@ -914,6 +922,12 @@ commands:
           before the max number of polling attempts is reached.
         type: boolean
         default: false
+      verification-timeout:
+        description: |
+          The maximum amount of time to wait for a blue/green deployment to complete before timing out.
+          Only in use when the deployment controller is the blue/green deployment type.
+        type: string
+        default: "10m"
       max-poll-attempts:
         description: |
           The maximum number of attempts to poll the deployment status before giving up.
@@ -957,46 +971,56 @@ commands:
                     --output text \
                     --query 'taskDefinition.taskDefinitionArn')
                   echo "export CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN='${TASK_DEFINITION_ARN}'" >> $BASH_ENV
-      - run:
-          name: Update service with registered task definition
-          command: |
-            set -o noglob
-            DEPLOYMENT_CONTROLLER="$(echo << parameters.deployment-controller >>)"
+      - when:
+          condition: 
+            - not: 
+                equal: [ "ECS", << parameters.deployment-controller >> ]
+          steps:
+            - run:
+                name: Update ECS Blue/Green service with registered task definition.
+                command: | 
+                  set -o noglob
+                  DEPLOYMENT_CONTROLLER="$(echo << parameters.deployment-controller >>)"
+                  DEPLOYED_REVISION="${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN}"
+                  DEPLOYMENT_ID=$(aws deploy create-deployment \
+                      --application-name "<< parameters.codedeploy-application-name >>" \
+                      --deployment-group-name "<< parameters.codedeploy-deployment-group-name >>" \
+                      --revision "{\"revisionType\": \"AppSpecContent\", \"appSpecContent\": {\"content\": \"{\\\"version\\\": 1, \\\"Resources\\\": [{\\\"TargetService\\\": {\\\"Type\\\": \\\"AWS::ECS::Service\\\", \\\"Properties\\\": {\\\"TaskDefinition\\\": \\\"${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN}\\\", \\\"LoadBalancerInfo\\\": {\\\"ContainerName\\\": \\\"<< parameters.codedeploy-load-balanced-container-name >>\\\", \\\"ContainerPort\\\": << parameters.codedeploy-load-balanced-container-port >>}}}}]}\"}}" \
+                      --query deploymentId)
+                  echo "Created CodeDeploy deployment: $DEPLOYMENT_ID"
+                  if [ "<< parameters.verify-revision-is-deployed >>" == "true" ]; then
+                    echo "Waiting for deployment to succeed." 
+                    if $(aws deploy wait deployment-successful --deployment-id ${DEPLOYMENT_ID}); then
+                      echo "Deployment succeeded."
+                    else
+                      echo "Deployment failed."
+                    fi
+                  echo "export CCI_ORB_AWS_ECS_DEPLOYED_REVISION='${DEPLOYED_REVISION}'" >> $BASH_ENV
+          no_output_timeout: << parameters.verification-timeout >> 
+      - when:
+          condition:
+            - equal: [ "ECS", << parameters.deployment-controller >> ] 
+          steps: 
+            - run:
+              name: Update service with registered task definition
+              command: |
+                set -o noglob
+                SERVICE_NAME="$(echo << parameters.service-name >>)"
 
-            if [ "${DEPLOYMENT_CONTROLLER}" = "CODE_DEPLOY" ]; then
-                DEPLOYED_REVISION="${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN}"
-                DEPLOYMENT_ID=$(aws deploy create-deployment \
-                    --application-name "<< parameters.codedeploy-application-name >>" \
-                    --deployment-group-name "<< parameters.codedeploy-deployment-group-name >>" \
-                    --revision "{\"revisionType\": \"AppSpecContent\", \"appSpecContent\": {\"content\": \"{\\\"version\\\": 1, \\\"Resources\\\": [{\\\"TargetService\\\": {\\\"Type\\\": \\\"AWS::ECS::Service\\\", \\\"Properties\\\": {\\\"TaskDefinition\\\": \\\"${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN}\\\", \\\"LoadBalancerInfo\\\": {\\\"ContainerName\\\": \\\"<< parameters.codedeploy-load-balanced-container-name >>\\\", \\\"ContainerPort\\\": << parameters.codedeploy-load-balanced-container-port >>}}}}]}\"}}" \
-                    --query deploymentId)
-                echo "Created CodeDeploy deployment: $DEPLOYMENT_ID"
-                if [ "<< parameters.verify-revision-is-deployed >>" == "true" ]; then
-                  echo "Waiting for deployment to succeed." 
-                  if $(aws deploy wait deployment-successful --deployment-id ${DEPLOYMENT_ID}); then
-                    echo "Deployment succeeded."
-                  else
-                    echo "Deployment failed."
-                  fi
+                if [ -z "${SERVICE_NAME}" ]; then
+                    SERVICE_NAME="$(echo << parameters.family >>)"
                 fi
-            else
-              SERVICE_NAME="$(echo << parameters.service-name >>)"
-
-              if [ -z "${SERVICE_NAME}" ]; then
-                  SERVICE_NAME="$(echo << parameters.family >>)"
-              fi
-              if [ "<< parameters.force-new-deployment >>" == "true" ]; then
-                  set -- "$@" --force-new-deployment
-              fi
-              DEPLOYED_REVISION=$(aws ecs update-service \
-                  --cluster "<< parameters.cluster-name >>" \
-                  --service "${SERVICE_NAME}" \
-                  --task-definition "${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN}" \
-                  --output text \
-                  --query service.taskDefinition \
-                  "$@")
-            fi
-            echo "export CCI_ORB_AWS_ECS_DEPLOYED_REVISION='${DEPLOYED_REVISION}'" >> $BASH_ENV
+                if [ "<< parameters.force-new-deployment >>" == "true" ]; then
+                    set -- "$@" --force-new-deployment
+                fi
+                DEPLOYED_REVISION=$(aws ecs update-service \
+                    --cluster "<< parameters.cluster-name >>" \
+                    --service "${SERVICE_NAME}" \
+                    --task-definition "${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN}" \
+                    --output text \
+                    --query service.taskDefinition \
+                    "$@")
+                echo "export CCI_ORB_AWS_ECS_DEPLOYED_REVISION='${DEPLOYED_REVISION}'" >> $BASH_ENV
       - when:
           condition:
             and:

--- a/src/orb.yml.hbs
+++ b/src/orb.yml.hbs
@@ -988,12 +988,13 @@ commands:
                       --query deploymentId)
                   echo "Created CodeDeploy deployment: $DEPLOYMENT_ID"
                   if [ "<< parameters.verify-revision-is-deployed >>" == "true" ]; then
-                    echo "Waiting for deployment to succeed." 
+                    echo "Waiting for deployment to succeed."
                     if $(aws deploy wait deployment-successful --deployment-id ${DEPLOYMENT_ID}); then
                       echo "Deployment succeeded."
                     else
                       echo "Deployment failed."
                     fi
+                  fi
                   echo "export CCI_ORB_AWS_ECS_DEPLOYED_REVISION='${DEPLOYED_REVISION}'" >> $BASH_ENV
           no_output_timeout: << parameters.verification-timeout >> 
       - when:

--- a/src/orb.yml.hbs
+++ b/src/orb.yml.hbs
@@ -972,28 +972,12 @@ commands:
                     --query deploymentId)
                 echo "Created CodeDeploy deployment: $DEPLOYMENT_ID"
                 if [ "<< parameters.verify-revision-is-deployed >>" == "true" ]; then
-                  seconds=3600+$SECONDS
-                  while (( $SECONDS < $seconds )); do
-                    DEPLOYMENT_STATUS=$(aws deploy get-deployment --deployment-id $DEPLOYMENT_ID)  
-                    if grep "\"status\": \"Succeeded\"" \<<< $DEPLOYMENT_STATUS; then
-                      echo "Deployment Success" 
-                      exit 0  
-                    elif grep "\"status\": \"Failed\"" \<<< $DEPLOYMENT_STATUS; then 
-                      echo "Deployment Failed"
-                      exit 1 
-                    elif grep "\"status\": \"Stopped\"" \<<< $DEPLOYMENT_STATUS; then 
-                      echo "Deployment Stopped"
-                      exit 1 
-                    elif grep "\"status\": \"Skipped\"" \<<< $DEPLOYMENT_STATUS; then 
-                      echo "Deployment Skipped"
-                      exit 1 
-                    else
-                      echo "Sleeping for 1 minute before retrying the status of the deployment" 
-                      sleep 60s
-                    fi
-                  done
-                  echo "No response from Code deploy, exiting." 
-                  exit 1
+                  echo "Waiting for deployment to succeed." 
+                  if $(aws deploy wait deployment-successful --deployment-id ${DEPLOYMENT_ID}); then
+                    echo "Deployment succeeded."
+                  else
+                    echo "Deployment failed."
+                  fi
                 fi
             else
               SERVICE_NAME="$(echo << parameters.service-name >>)"

--- a/src/orb.yml.hbs
+++ b/src/orb.yml.hbs
@@ -983,6 +983,9 @@ commands:
                     elif grep "\"status\": \"Stopped\"" <<< $DEPLOYMENT_STATUS; then 
                       echo "Deployment Stopped"
                       exit 1 
+                    elif grep "\"status\": \"Skipped\"" <<< $DEPLOYMENT_STATUS; then 
+                      echo "Deployment Skipped"
+                      exit 0 
                     else
                       echo "Sleeping for 1 minute before retrying the status of the deployment" 
                       sleep 60s


### PR DESCRIPTION
### Checklist
- [ / ] All new jobs, commands, executors, parameters have descriptions
- [ / ] Examples have been added for any significant new features
- [ / ] README has been updated, if necessary

### Motivation, issues

When using the orb in it's current state, deployment statuses of the blue-green deployment aren't reported. As a result I get no feedback as to when my new revision's deployment has failed, or succeeded in placing tasks.

A similar issue has been reported by another user, and can be seen in the issue below.

https://github.com/CircleCI-Public/aws-ecs-orb/issues/93

### Description

Adds functionality for the CircleCI parameter `verify-revision-is-deployed` for Code_deploy controllers. 

To my understanding the command above doesn't exist on the AWS CLI, but, is being emulated by waiting for the deployment.

