### PR TITLE
[semver:patch] Add exit code 1 on failed deployment

### DIFF
--- a/src/orb.yml.hbs
+++ b/src/orb.yml.hbs
@@ -994,6 +994,7 @@ commands:
                       echo "Deployment succeeded."
                     else
                       echo "Deployment failed."
+                      exit 1
                     fi
                   fi
                   echo "export CCI_ORB_AWS_ECS_DEPLOYED_REVISION='${DEPLOYED_REVISION}'" >> $BASH_ENV


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [X] All new jobs, commands, executors, parameters have descriptions
- [X] Examples have been added for any significant new features
- [X] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

Currently, code deploy failures do not fail the job.  This adds a exit code so that the job fails properly and users are notified when a deployment isn't successful
