### PR TITLE
[semver:minor] Always allow platform-version overrides

### DIFF
--- a/src/commands/run-task.yml
+++ b/src/commands/run-task.yml
@@ -57,10 +57,10 @@ parameters:
     default: FARGATE
   platform-version:
     description: |
-      The platform version the task should run.
-      A platform version is only specified for tasks using the Fargate launch type.
+      Use this to specify the platform version that the task should run on.
+      A platform version should only be specified for tasks using the Fargate launch type.
     type: string
-    default: LATEST
+    default: ''
   awsvpc:
     description: |
       Does your task defintion use awsvpc mode or not.

--- a/src/jobs/run-task.yml
+++ b/src/jobs/run-task.yml
@@ -78,10 +78,10 @@ parameters:
     default: FARGATE
   platform-version:
     description: |
-      "The platform version the task should run. A platform version is only
-      specified for tasks using the Fargate launch type."
+      Use this to specify the platform version that the task should run on.
+      A platform version should only be specified for tasks using the Fargate launch type.
     type: string
-    default: LATEST
+    default: ''
   awsvpc:
     description: |
       "Does your task definition use awsvpc mode or not. If so,

--- a/src/scripts/run-task.sh
+++ b/src/scripts/run-task.sh
@@ -3,7 +3,7 @@ ECS_PARAM_CLUSTER_NAME=$(eval echo "$ECS_PARAM_CLUSTER_NAME")
 ECS_PARAM_TASK_DEF=$(eval echo "$ECS_PARAM_TASK_DEF")
 
 set -o noglob
-if [ "$ECS_PARAM_LAUNCH_TYPE" == "FARGATE" ]; then
+if [ -n "$ECS_PARAM_PLATFORM_VERSION" ]; then
     echo "Setting --platform-version"
     set -- "$@" --platform-version "$ECS_PARAM_PLATFORM_VERSION"
 fi


### PR DESCRIPTION
Resolves https://github.com/CircleCI-Public/aws-ecs-orb/issues/121

Change the default value for the `platform-version` command/job parameter from `LATEST` to `''`, and only provide the `--platform-version` argument to the AWS CLI when `platform-version` is non-blank.

The AWS CLI docs for `--platform-version` (https://docs.aws.amazon.com/cli/latest/reference/ecs/run-task.html) state:

```
If one is not specified, the LATEST platform version is used by default
```

Hence, this PR should generally be a backwards-compatible change since the AWS CLI already uses `LATEST`  as the default when no `--platform-version` argument is provided to the CLI anyway, so not passing `--platform-version` (which will be the new orb default behavior) should have the same effect as explicitly setting `--platform-version LATEST` when the launch type is `FARGATE`, as the orb would do in the past.