### PR TITLE
[semver:minor] Add support for tagging of task-definition to update-service command

### DIFF
--- a/src/commands/update-service.yml
+++ b/src/commands/update-service.yml
@@ -151,7 +151,7 @@ steps:
             name: Update task definition with additional tags
             command: >
               aws ecs tag-resource \
-                --task-definition "${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN}" \
+                --resource-arn "${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN}" \
                 --tags "<<parameters.task-definition-tags>>"
   - when:
       condition:

--- a/src/commands/update-service.yml
+++ b/src/commands/update-service.yml
@@ -121,9 +121,9 @@ parameters:
 
       Expected formats:
         - Shorthand Syntax
-          key=string,value=string,key=...,value=...,
+          key=string,value=string ...
         - JSON Syntax
-         [{"key": "string","value": "string"}...]
+         [{"key": "string","value": "string"} ... ]
 
       Values should not contain commas.
     type: string

--- a/src/commands/update-service.yml
+++ b/src/commands/update-service.yml
@@ -119,8 +119,11 @@ parameters:
 
       (Existing environment variables not included in this parameter will not be removed)
 
-      Expected format:
-      key=string,value=string,key=...,value=...,
+      Expected formats:
+        - Shorthand Syntax
+          key=string,value=string,key=...,value=...,
+        - JSON Syntax
+         [{"key": "string","value": "string"}...]
 
       Values should not contain commas.
     type: string

--- a/src/commands/update-service.yml
+++ b/src/commands/update-service.yml
@@ -112,6 +112,19 @@ parameters:
       Whether to skip registration of a new task definition.
     type: boolean
     default: false
+  task-definition-tags:
+    description: >
+      The metadata that you apply to the task definition to help you categorize and organize them.
+      Each tag consists of a key and an optional value, both of which you define.
+
+      (Existing environment variables not included in this parameter will not be removed)
+
+      Expected format:
+      key=string,value=string,key=...,value=...,
+
+      Values should not contain commas.
+    type: string
+    default: ''
 steps:
   - unless:
       condition: << parameters.skip-task-definition-registration >>
@@ -131,6 +144,15 @@ steps:
                 --output text \
                 --query 'taskDefinition.taskDefinitionArn')
               echo "export CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN='${TASK_DEFINITION_ARN}'" >> $BASH_ENV
+  - when:
+      condition: << parameters.task-definition-tags >>
+      steps:
+        - run:
+            name: Update task definition with additional tags
+            command: >
+              aws ecs tag-resource \
+                --task-definition "${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN}" \
+                --tags "<<parameters.task-definition-tags>>"
   - when:
       condition:
         equal:

--- a/src/jobs/deploy-service-update.yml
+++ b/src/jobs/deploy-service-update.yml
@@ -160,9 +160,15 @@ parameters:
     description: >
       The metadata that you apply to the task definition to help you categorize and organize them.
       Each tag consists of a key and an optional value, both of which you define.
+
       (Existing environment variables not included in this parameter will not be removed)
-      Expected format:
-      key=string,value=string,key=...,value=...,
+
+      Expected formats:
+        - Shorthand Syntax
+          key=string,value=string,key=...,value=...,
+        - JSON Syntax
+         [{"key": "string","value": "string"}...]
+
       Values should not contain commas.
     type: string
     default: ''

--- a/src/jobs/deploy-service-update.yml
+++ b/src/jobs/deploy-service-update.yml
@@ -156,6 +156,16 @@ parameters:
       Whether to skip registration of a new task definition.
     type: boolean
     default: false
+  task-definition-tags:
+    description: >
+      The metadata that you apply to the task definition to help you categorize and organize them.
+      Each tag consists of a key and an optional value, both of which you define.
+      (Existing environment variables not included in this parameter will not be removed)
+      Expected format:
+      key=string,value=string,key=...,value=...,
+      Values should not contain commas.
+    type: string
+    default: ''
 steps:
   - aws-cli/setup:
       aws-access-key-id: << parameters.aws-access-key-id >>
@@ -178,4 +188,5 @@ steps:
       poll-interval: << parameters.poll-interval >>
       fail-on-verification-timeout: << parameters.fail-on-verification-timeout >>
       skip-task-definition-registration: << parameters.skip-task-definition-registration >>
+      task-definition-tags: << parameters.task-definition-tags >>
       verification-timeout: << parameters.verification-timeout >>

--- a/src/jobs/deploy-service-update.yml
+++ b/src/jobs/deploy-service-update.yml
@@ -165,9 +165,9 @@ parameters:
 
       Expected formats:
         - Shorthand Syntax
-          key=string,value=string,key=...,value=...,
+          key=string,value=string ...
         - JSON Syntax
-         [{"key": "string","value": "string"}...]
+         [{"key": "string","value": "string"} ... ]
 
       Values should not contain commas.
     type: string


### PR DESCRIPTION
Fix for https://github.com/CircleCI-Public/aws-ecs-orb/issues/120

If the `task-definition-tags` parameter is specified for the update-service command. The task definition will be updated with the tag specified.