### PR TITLE
[semver:patch] fix unexpected string interpolation when using the task-definition-tags argument

### DIFF
--- a/src/commands/update-service.yml
+++ b/src/commands/update-service.yml
@@ -154,8 +154,8 @@ steps:
             name: Update task definition with additional tags
             command: >
               aws ecs tag-resource \
-                --resource-arn "${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN}" \
-                --tags "<<parameters.task-definition-tags>>"
+                --resource-arn ${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN} \
+                --tags <<parameters.task-definition-tags>>
   - when:
       condition:
         equal:


### PR DESCRIPTION
remove unnecessary quotes which create confusion around string interpolation.

These quotes make the command difficult to use, for example if you want to quote you values which may have special characters. It also throws an error if more than one key/value is used with the simple format. The json format also requires quotes around key/values which makes the removed quotes troublesome. Below are some of the manual tests I did via inlining the orb to show what I mean.

### Before change:
Works:
`task-definition-tags:     key=key1,value=value1`
Doesn't Work
```
task-definition-tags:     key=key1,value=value1 key=key2,value=value2
...

Error parsing parameter '--tags': Second instance of key "value" encountered for input:
key=key1,value=value1 key=key2,value=value2
                               ^
This is often because there is a preceeding "," instead of a space.
```

### After change:
Works:
`task-definition-tags:     key=key1,value=value1`
`task-definition-tags:     key=tag,value="${CIRCLE_TAG}" key=BuildURL,value="${CIRCLE_BUILD_URL}"`
`task-definition-tags: "'[{\"key\": \"ReleaseIDTest\", \"value\": \"test\"}, {\"key\": \"BuildURLTest\",\"value\": \"test\"}]'"`

Still Doesn't Work

```
task-definition-tags: "'[{\"key\": \"ReleaseIDTest\", \"value\": \"${CIRCLE_TAG}\"}, {\"key\": \"BuildURLTest\",\"value\": \"${CIRCLE_BUILD_URL}\"}]'"
...
Error: An error occurred (ClientException) when calling the TagResource operation: Some tags contain invalid characters. Valid characters: UTF-8 letters, spaces, numbers and _ . / = + - : @.
```
^ Although confusing. I would say is expected. Since the evaluation of the env variable are not happening based on the quotes. In this scenario the json need to be pre processed with jq or something like that. The single quotes are required for the json input by the aws cli. eg.

```
aws ecs tag-resource   --resource-arn "***"   --tags [{"key": "ReleaseIDTest", "value": "abc"}, {"key": "BuildURLTest","value": "abc"}]

Error parsing parameter '--tags': Invalid JSON:
[{key:
```