### PR TITLE
[semver:patch] add revision when query for previous task definition

### DIFF
--- a/src/commands/update-service.yml
+++ b/src/commands/update-service.yml
@@ -4,6 +4,10 @@ parameters:
   family:
     description: Name of the task definition's family.
     type: string
+  previous-revision:
+    description: Optional previous task's revision number
+    type: string
+    default: ''
   cluster-name:
     description: The short name or full ARN of the cluster that hosts the service.
     type: string
@@ -186,6 +190,7 @@ steps:
             environment:
               ECS_PARAM_SERVICE_NAME: <<parameters.service-name>>
               ECS_PARAM_FAMILY: <<parameters.family>>
+              ECS_PARAM_PREVIOUS_REVISION: <<parameters.previous-revision>>
               ECS_PARAM_FORCE_NEW_DEPLOY: <<parameters.force-new-deployment>>
               ECS_PARAM_CLUSTER_NAME: << parameters.cluster-name >>
 

--- a/src/scripts/get-prev-task.sh
+++ b/src/scripts/get-prev-task.sh
@@ -2,12 +2,18 @@ set -o noglob
 
 # These variables are evaluated so the config file may contain and pass in environment variables to the parameters.
 ECS_PARAM_FAMILY=$(eval echo "$ECS_PARAM_FAMILY")
+ECS_PARAM_PREVIOUS_REVISION=$(eval echo "$ECS_PARAM_PREVIOUS_REVISION")
 ECS_PARAM_CONTAINER_IMAGE_NAME_UPDATES=$(eval echo "$ECS_PARAM_CONTAINER_IMAGE_NAME_UPDATES")
 ECS_PARAM_CONTAINER_ENV_VAR_UPDATES=$(eval echo "$ECS_PARAM_CONTAINER_ENV_VAR_UPDATES")
 
 # shellcheck disable=SC2034
-PREVIOUS_TASK_DEFINITION=$(aws ecs describe-task-definition --task-definition "$ECS_PARAM_FAMILY" --include TAGS)
+if [ -z "${ECS_PARAM_PREVIOUS_REVISION}" ]; then
+  ECS_TASK_DEFINITION_NAME="$ECS_PARAM_FAMILY"
+else
+  ECS_TASK_DEFINITION_NAME="$ECS_PARAM_FAMILY:$ECS_PARAM_PREVIOUS_REVISION"
+fi
 
+PREVIOUS_TASK_DEFINITION=$(aws ecs describe-task-definition --task-definition "$ECS_TASK_DEFINITION_NAME" --include TAGS)
 
 
 # Prepare script for updating container definitions


### PR DESCRIPTION
Querying for previous task like that:
```PREVIOUS_TASK_DEFINITION=$(aws ecs describe-task-definition --task-definition "$ECS_PARAM_FAMILY" --include TAGS)``` 
is not enough in my case while I have multiple task definitions for different clusters but in the same family.
According to AWS doc (https://docs.aws.amazon.com/cli/latest/reference/ecs/describe-task-definition.html) it's possible to include revision while querying for task definition. 

My PR is a proposal to use optional revision number for previous task definitions.