### PR TITLE
feat: Add profile-name parameter to all commands and jobs

### DIFF
--- a/src/commands/run-task.yml
+++ b/src/commands/run-task.yml
@@ -112,6 +112,10 @@ parameters:
       If no value is specified, the tags are not propagated. Tags can only be propagated to the task during task creation. To add tags to a task after task creation, use the TagResource API action.
     type: boolean
     default: false
+  profile-name:
+    description: AWS profile name to be configured.
+    type: string
+    default: ''
 steps:
   - run:
       name: Run Task
@@ -135,3 +139,4 @@ steps:
         ECS_PARAM_ENABLE_ECS_MANAGED_TAGS: <<parameters.enable-ecs-managed-tags>>
         ECS_PARAM_PROPAGATE_TAGS: <<parameters.propagate-tags>>
         ECS_PARAM_CAPACITY_PROVIDER_STRATEGY: <<parameters.capacity-provider-strategy>>
+        ECS_PARAM_PROFILE_NAME: <<parameters.profile-name>>

--- a/src/commands/update-service.yml
+++ b/src/commands/update-service.yml
@@ -128,6 +128,10 @@ parameters:
       Values should not contain commas.
     type: string
     default: ''
+  profile-name:
+    description: AWS profile name to be configured.
+    type: string
+    default: ''
 steps:
   - unless:
       condition: << parameters.skip-task-definition-registration >>
@@ -136,16 +140,19 @@ steps:
             family: << parameters.family >>
             container-image-name-updates: << parameters.container-image-name-updates >>
             container-env-var-updates: << parameters.container-env-var-updates >>
+            profile-name: << parameters.profile-name >>
   - when:
       condition: << parameters.skip-task-definition-registration >>
       steps:
         - run:
             name: Retrieve previous task definition
             command: >
+
               TASK_DEFINITION_ARN=$(aws ecs describe-task-definition \
                 --task-definition << parameters.family >> \
                 --output text \
-                --query 'taskDefinition.taskDefinitionArn')
+                --query 'taskDefinition.taskDefinitionArn' \
+                --profile=<< parameters.profile-name >>)
               echo "export CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN='${TASK_DEFINITION_ARN}'" >> $BASH_ENV
   - when:
       condition: << parameters.task-definition-tags >>
@@ -155,7 +162,8 @@ steps:
             command: >
               aws ecs tag-resource \
                 --resource-arn ${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN} \
-                --tags <<parameters.task-definition-tags>>
+                --tags <<parameters.task-definition-tags>> \
+                --profile=<< parameters.profile-name >>
   - when:
       condition:
         equal:
@@ -172,6 +180,7 @@ steps:
               ECS_PARAM_CD_LOAD_BALANCED_CONTAINER_NAME: <<parameters.codedeploy-load-balanced-container-name>>
               ECS_PARAM_CD_LOAD_BALANCED_CONTAINER_PORT: <<parameters.codedeploy-load-balanced-container-port>>
               ECS_PARAM_VERIFY_REV_DEPLOY: <<parameters.verify-revision-is-deployed>>
+              ECS_PARAM_PROFILE_NAME: <<parameters.profile-name>>
 
       no_output_timeout: << parameters.verification-timeout >>
   - when:
@@ -188,6 +197,7 @@ steps:
               ECS_PARAM_FAMILY: <<parameters.family>>
               ECS_PARAM_FORCE_NEW_DEPLOY: <<parameters.force-new-deployment>>
               ECS_PARAM_CLUSTER_NAME: << parameters.cluster-name >>
+              ECS_PARAM_PROFILE_NAME: <<parameters.profile-name>>
 
   - when:
       condition:
@@ -205,3 +215,4 @@ steps:
             max-poll-attempts: << parameters.max-poll-attempts >>
             poll-interval: << parameters.poll-interval >>
             fail-on-verification-timeout: << parameters.fail-on-verification-timeout >>
+            profile-name: << parameters.profile-name >>

--- a/src/commands/update-task-definition-from-json.yml
+++ b/src/commands/update-task-definition-from-json.yml
@@ -4,9 +4,14 @@ parameters:
     description: |
       Location of your .json task definition file (relative or absolute).
     type: string
+  profile-name:
+    description: AWS profile name to be configured.
+    type: string
+    default: ''
 steps:
   - run:
       name: Register new task definition
       command: <<include(scripts/update-task-definition-from-json.sh)>>
       environment:
         ECS_PARAM_TASK_DEFINITION_JSON: <<parameters.task-definition-json>>
+        ECS_PARAM_PROFILE_NAME: <<parameters.profile-name>>

--- a/src/commands/update-task-definition.yml
+++ b/src/commands/update-task-definition.yml
@@ -32,6 +32,10 @@ parameters:
       Values should not contain commas.
     type: string
     default: ''
+  profile-name:
+    description: AWS profile name to be configured.
+    type: string
+    default: ''
 steps:
   - run:
       name: Retrieve previous task definition and prepare new task definition values
@@ -40,6 +44,7 @@ steps:
         ECS_PARAM_FAMILY: <<parameters.family>>
         ECS_PARAM_CONTAINER_IMAGE_NAME_UPDATES: <<parameters.container-image-name-updates>>
         ECS_PARAM_CONTAINER_ENV_VAR_UPDATES: <<parameters.container-env-var-updates>>
+        ECS_PARAM_PROFILE_NAME: <<parameters.profile-name>>
         ECS_SCRIPT_UPDATE_CONTAINER_DEFS: <<include(scripts/update_container_defs.py)>>
         ECS_SCRIPT_GET_TASK_DFN_VAL: <<include(scripts/get_task_dfn_val.py)>>
 
@@ -49,3 +54,4 @@ steps:
       command: <<include(scripts/register-new-task-def.sh)>>
       environment:
         ECS_PARAM_FAMILY: <<parameters.family>>
+        ECS_PARAM_PROFILE_NAME: <<parameters.profile-name>>

--- a/src/commands/verify-revision-is-deployed.yml
+++ b/src/commands/verify-revision-is-deployed.yml
@@ -30,6 +30,10 @@ parameters:
       Whether to exit with an error if the verification of the deployment status does not complete within the number of polling attempts.
     type: boolean
     default: true
+  profile-name:
+    description: AWS profile name to be configured.
+    type: string
+    default: ''
 steps:
   - run:
       name: Verify that the revision is deployed and older revisions are stopped
@@ -44,3 +48,4 @@ steps:
         ECS_PARAM_CLUSTER_NAME: <<parameters.cluster-name>>
         ECS_PARAM_POLL_INTERVAL: <<parameters.poll-interval>>
         ECS_PARAM_FAIL_ON_VERIFY_TIMEOUT: <<parameters.fail-on-verification-timeout>>
+        ECS_PARAM_PROFILE_NAME: <<parameters.profile-name>>

--- a/src/examples/verify-revision-deplopyment.yml
+++ b/src/examples/verify-revision-deplopyment.yml
@@ -11,8 +11,9 @@ usage:
       steps:
         - aws-cli/setup:
             # If these values have not been modified from their default, they do not need to be included.
-            aws-access-key-id: AWS_SECRET_ACCESS_KEY
-            aws-secret-access-key: AWS_DEFAULT_REGION
+            # If they are included, they configure the "default" profile, which is specified below.
+            aws-access-key-id: AWS_ACCESS_KEY_ID
+            aws-secret-access-key: AWS_SECRET_ACCESS_KEY
             aws-region: AWS_DEFAULT_REGION
         - run:
             name: Get last task definition
@@ -20,7 +21,8 @@ usage:
               TASK_DEFINITION_ARN=$(aws ecs describe-task-definition \
                   --task-definition ${MY_APP_PREFIX}-service \
                   --output text \
-                  --query 'taskDefinition.taskDefinitionArn')
+                  --query 'taskDefinition.taskDefinitionArn' \
+                  --profile default)
               echo "export TASK_DEFINITION_ARN='${TASK_DEFINITION_ARN}'" >>
               $BASH_ENV
         - aws-ecs/verify-revision-is-deployed:

--- a/src/jobs/deploy-service-update.yml
+++ b/src/jobs/deploy-service-update.yml
@@ -19,6 +19,10 @@ parameters:
     description: AWS region to operate in. Set this to the name of the environment variable you will use to hold this value, i.e. AWS_DEFAULT_REGION.
     type: env_var_name
     default: AWS_DEFAULT_REGION
+  profile-name:
+    description: AWS profile name to be configured.
+    type: string
+    default: default
   family:
     description: Name of the task definition's family.
     type: string
@@ -177,6 +181,7 @@ steps:
       aws-access-key-id: << parameters.aws-access-key-id >>
       aws-secret-access-key: << parameters.aws-secret-access-key >>
       aws-region: << parameters.aws-region >>
+      profile-name: << parameters.profile-name >>
   - update-service:
       family: << parameters.family >>
       cluster-name: << parameters.cluster-name >>
@@ -196,3 +201,4 @@ steps:
       skip-task-definition-registration: << parameters.skip-task-definition-registration >>
       task-definition-tags: << parameters.task-definition-tags >>
       verification-timeout: << parameters.verification-timeout >>
+      profile-name: << parameters.profile-name >>

--- a/src/jobs/run-task.yml
+++ b/src/jobs/run-task.yml
@@ -19,6 +19,10 @@ parameters:
     description: AWS region to operate in. Set this to the name of the environment variable you will use to hold this value, i.e. AWS_DEFAULT_REGION.
     type: env_var_name
     default: AWS_DEFAULT_REGION
+  profile-name:
+    description: AWS profile name to be configured.
+    type: string
+    default: default
   cluster:
     description: The name or ARN of the cluster on which to run the task.
     type: string
@@ -150,6 +154,7 @@ steps:
       aws-access-key-id: << parameters.aws-access-key-id >>
       aws-secret-access-key: << parameters.aws-secret-access-key >>
       aws-region: << parameters.aws-region >>
+      profile-name: << parameters.profile-name >>
   - run-task:
       cluster: << parameters.cluster >>
       task-definition: << parameters.task-definition >>
@@ -169,3 +174,4 @@ steps:
       enable-ecs-managed-tags: << parameters.enable-ecs-managed-tags >>
       propagate-tags: << parameters.propagate-tags >>
       capacity-provider-strategy: << parameters.capacity-provider-strategy >>
+      profile-name: << parameters.profile-name >>

--- a/src/jobs/update-task-definition-from-json.yml
+++ b/src/jobs/update-task-definition-from-json.yml
@@ -19,6 +19,10 @@ parameters:
     description: AWS region to operate in. Set this to the name of the environment variable you will use to hold this value, i.e. AWS_DEFAULT_REGION.
     type: env_var_name
     default: AWS_DEFAULT_REGION
+  profile-name:
+    description: AWS profile name to be configured.
+    type: string
+    default: default
   task-definition-json:
     description: |
       Location of your .json task definition file (relative or absolute).
@@ -28,5 +32,7 @@ steps:
       aws-access-key-id: << parameters.aws-access-key-id >>
       aws-secret-access-key: << parameters.aws-secret-access-key >>
       aws-region: << parameters.aws-region >>
+      profile-name: << parameters.profile-name >>
   - update-task-definition-from-json:
       task-definition-json: << parameters.task-definition-json >>
+      profile-name: << parameters.profile-name >>

--- a/src/jobs/update-task-definition.yml
+++ b/src/jobs/update-task-definition.yml
@@ -19,6 +19,10 @@ parameters:
     description: AWS region to operate in. Set this to the name of the environment variable you will use to hold this value, i.e. AWS_DEFAULT_REGION.
     type: env_var_name
     default: AWS_DEFAULT_REGION
+  profile-name:
+    description: AWS profile name to be configured.
+    type: string
+    default: default
   family:
     description: Name of the task definition's family.
     type: string
@@ -63,7 +67,9 @@ steps:
       aws-access-key-id: << parameters.aws-access-key-id >>
       aws-secret-access-key: << parameters.aws-secret-access-key >>
       aws-region: << parameters.aws-region >>
+      profile-name: << parameters.profile-name >>
   - update-task-definition:
       family: << parameters.family >>
       container-image-name-updates: << parameters.container-image-name-updates >>
       container-env-var-updates: << parameters.container-env-var-updates >>
+      profile-name: << parameters.profile-name >>

--- a/src/scripts/get-prev-task.sh
+++ b/src/scripts/get-prev-task.sh
@@ -6,7 +6,7 @@ ECS_PARAM_CONTAINER_IMAGE_NAME_UPDATES=$(eval echo "$ECS_PARAM_CONTAINER_IMAGE_N
 ECS_PARAM_CONTAINER_ENV_VAR_UPDATES=$(eval echo "$ECS_PARAM_CONTAINER_ENV_VAR_UPDATES")
 
 # shellcheck disable=SC2034
-PREVIOUS_TASK_DEFINITION=$(aws ecs describe-task-definition --task-definition "$ECS_PARAM_FAMILY" --include TAGS)
+PREVIOUS_TASK_DEFINITION=$(aws ecs describe-task-definition --task-definition "$ECS_PARAM_FAMILY" --include TAGS --profile="$ECS_PARAM_PROFILE_NAME")
 
 
 

--- a/src/scripts/register-new-task-def.sh
+++ b/src/scripts/register-new-task-def.sh
@@ -56,7 +56,8 @@ REVISION=$(aws ecs register-task-definition \
     --container-definitions "${CCI_ORB_AWS_ECS_CONTAINER_DEFS}" \
     "$@" \
     --output text \
-    --query 'taskDefinition.taskDefinitionArn')
+    --query 'taskDefinition.taskDefinitionArn' \
+    --profile="$ECS_PARAM_PROFILE_NAME")
 echo "Registered task definition: ${REVISION}"
 
 echo "export CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN='${REVISION}'" >> "$BASH_ENV"

--- a/src/scripts/run-task.sh
+++ b/src/scripts/run-task.sh
@@ -68,6 +68,10 @@ if [ -n "$ECS_PARAM_LAUNCH_TYPE" ]; then
     fi
 fi
 
+if [ -n "${ECS_PARAM_PROFILE_NAME}" ]; then
+    set -- "$@" --profile "${ECS_PARAM_PROFILE_NAME}"
+fi
+
 echo "Setting --count"
 set -- "$@" --count "$ECS_PARAM_COUNT"
 echo "Setting --task-definition"

--- a/src/scripts/update-service-via-task-def.sh
+++ b/src/scripts/update-service-via-task-def.sh
@@ -19,5 +19,6 @@ DEPLOYED_REVISION=$(aws ecs update-service \
     --task-definition "${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN}" \
     --output text \
     --query service.taskDefinition \
+    --profile="$ECS_PARAM_PROFILE_NAME" \
     "$@")
 echo "export CCI_ORB_AWS_ECS_DEPLOYED_REVISION='${DEPLOYED_REVISION}'" >> "$BASH_ENV"

--- a/src/scripts/update-task-definition-from-json.sh
+++ b/src/scripts/update-task-definition-from-json.sh
@@ -5,7 +5,8 @@ fi
 REVISION=$(aws ecs register-task-definition \
     --cli-input-json file://"${ECS_PARAM_TASK_DEFINITION_JSON}" \
     --output text \
-    --query 'taskDefinition.taskDefinitionArn')
+    --query 'taskDefinition.taskDefinitionArn' \
+    --profile="$ECS_PARAM_PROFILE_NAME")
 echo "Registered task definition: ${REVISION}"
 
 echo "export CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN='${REVISION}'" >> "$BASH_ENV"

--- a/src/scripts/verify-revision-is-deployed.sh
+++ b/src/scripts/verify-revision-is-deployed.sh
@@ -26,17 +26,20 @@ do
         --cluster "$ECS_PARAM_CLUSTER_NAME" \
         --services "${ECS_PARAM_SERVICE_NAME}" \
         --output text \
-        --query 'services[0].deployments[].[taskDefinition, status]')
+        --query 'services[0].deployments[].[taskDefinition, status]' \
+        --profile="$ECS_PARAM_PROFILE_NAME")
     NUM_DEPLOYMENTS=$(aws ecs describe-services \
         --cluster "$ECS_PARAM_CLUSTER_NAME" \
         --services "${ECS_PARAM_SERVICE_NAME}" \
         --output text \
-        --query 'length(services[0].deployments)')
+        --query 'length(services[0].deployments)' \
+        --profile="$ECS_PARAM_PROFILE_NAME")
     TARGET_REVISION=$(aws ecs describe-services \
         --cluster "$ECS_PARAM_CLUSTER_NAME" \
         --services "${ECS_PARAM_SERVICE_NAME}" \
         --output text \
-        --query "services[0].deployments[?taskDefinition==\`$ECS_PARAM_TASK_DEF_ARN\` && runningCount == desiredCount && (status == \`PRIMARY\` || status == \`ACTIVE\`)][taskDefinition]")
+        --query "services[0].deployments[?taskDefinition==\`$ECS_PARAM_TASK_DEF_ARN\` && runningCount == desiredCount && (status == \`PRIMARY\` || status == \`ACTIVE\`)][taskDefinition]" \
+        --profile="$ECS_PARAM_PROFILE_NAME")
     echo "Current deployments: $DEPLOYMENTS"
     if [ "$NUM_DEPLOYMENTS" = "1" ] && [ "$TARGET_REVISION" = "$ECS_PARAM_TASK_DEF_ARN" ]; then
         echo "The task definition revision $TARGET_REVISION is the only deployment for the service and has attained the desired running task count."


### PR DESCRIPTION
Fixes https://github.com/CircleCI-Public/aws-ecs-orb/issues/148

I'm running this fork in my own workflows and it solves the issue with AWS credentials in the environment overriding the ones specified on the orb commands: https://circleci.com/developer/orbs/orb/loancrate/aws-ecs