### PR TITLE
fix: Update Terraform and AWS Provider versions

### DIFF
--- a/tests/terraform_setup/ec2/terraform.tf
+++ b/tests/terraform_setup/ec2/terraform.tf
@@ -1,18 +1,22 @@
 terraform {
-  required_version = ">= 0.12"
+  required_providers {
+    aws = {
+      version = "~> 4.13"
+    }
+  }
   backend "s3" {
     bucket         = "aws-ecs-terraform-state-bucket-ec2"
     key            = "tf/state"
     region         = "us-west-2"
     dynamodb_table = "aws-ecs-terraform-state-lock-db-ec2"
   }
+  required_version = ">= 1.1"
 }
 
 provider "aws" {
   access_key = var.aws_access_key
   secret_key = var.aws_secret_key
   region     = var.aws_region
-  version    = "~> 2.7"
 }
 
 locals {

--- a/tests/terraform_setup/fargate/terraform.tf
+++ b/tests/terraform_setup/fargate/terraform.tf
@@ -1,18 +1,22 @@
 terraform {
-  required_version = ">= 0.12"
+  required_providers {
+    aws = {
+      version = "~> 4.13"
+    }
+  }
   backend "s3" {
     bucket         = "aws-ecs-terraform-state-bucket-fargate"
     key            = "tf/state"
     region         = "us-west-2"
     dynamodb_table = "aws-ecs-terraform-state-lock-db-fargate"
   }
+  required_version = ">= 1.1"
 }
 
 provider "aws" {
   access_key = var.aws_access_key
   secret_key = var.aws_secret_key
   region     = var.aws_region
-  version    = "~> 2.7"
 }
 
 locals {

--- a/tests/terraform_setup/fargate_codedeploy/terraform.tf
+++ b/tests/terraform_setup/fargate_codedeploy/terraform.tf
@@ -1,18 +1,22 @@
 terraform {
-  required_version = ">= 0.12"
+  required_providers {
+    aws = {
+      version = "~> 4.13"
+    }
+  }
   backend "s3" {
     bucket         = "aws-ecs-terraform-state-bucket-codedeploy-fargate"
     key            = "tf/state"
     region         = "us-west-2"
     dynamodb_table = "aws-ecs-terraform-state-lock-db-codedeploy-fargate"
   }
+  required_version = ">= 1.1"
 }
 
 provider "aws" {
   access_key = var.aws_access_key
   secret_key = var.aws_secret_key
   region     = var.aws_region
-  version    = "~> 2.7"
 }
 
 locals {


### PR DESCRIPTION
This PR includes the following: 

- Addressing deprecation warnings
- Updating Terraform and AWS Provider versions
- Adding version constraints into `required_providers` block