### PR TITLE
feat: Add `profile-name` Parameter 

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -179,6 +179,10 @@ jobs:
         description: "Skip updating the ECS service"
         type: boolean
         default: false
+      profile-name:
+        description: "The profile name to use for AWS credentials"
+        type: string
+        default: "default"
     steps:
       - checkout
       - setup_remote_docker
@@ -201,7 +205,7 @@ jobs:
       - run:
           name: Push image
           command: |
-            aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com
+            aws ecr get-login-password --region $AWS_DEFAULT_REGION --profile "<<parameters.profile-name>>" | docker login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com
             docker push $FULL_IMAGE_NAME
       - unless:
           condition: << parameters.skip-service-update >>
@@ -214,6 +218,7 @@ jobs:
                 container-env-var-updates: 'container=<< parameters.aws-resource-name-prefix >>-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=<< parameters.aws-resource-name-prefix >>-service,name=BUILD_DATE,value=$(date)'
                 verify-revision-is-deployed: true
                 fail-on-verification-timeout: false
+                profile-name: "<<parameters.profile-name>>"
             - test-deployment:
                 service-name: "<< parameters.aws-resource-name-prefix >>-service"
                 cluster-name: "<< parameters.aws-resource-name-prefix >>-cluster"
@@ -367,6 +372,7 @@ workflows:
             - fargate_test-update-service-command
           aws-access-key-id: AWS_ACCESS_KEY_ID
           aws-region: AWS_DEFAULT_REGION
+          profile-name: "ECS_TEST_PROFILE"
           family: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
           cluster-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
           container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service,name=BUILD_DATE,value=$(date)'
@@ -388,6 +394,7 @@ workflows:
             - fargate_test-update-service-job
           aws-access-key-id: AWS_ACCESS_KEY_ID
           aws-region: AWS_DEFAULT_REGION
+          profile-name: "ECS_TEST_PROFILE"
           family: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
           cluster-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
           # test skipping registration of a new task definition

--- a/src/commands/run-task.yml
+++ b/src/commands/run-task.yml
@@ -112,6 +112,10 @@ parameters:
       If no value is specified, the tags are not propagated. Tags can only be propagated to the task during task creation. To add tags to a task after task creation, use the TagResource API action.
     type: boolean
     default: false
+  profile-name:
+    description: AWS profile name to be configured.
+    type: string
+    default: ''
 steps:
   - run:
       name: Run Task
@@ -135,3 +139,4 @@ steps:
         ECS_PARAM_ENABLE_ECS_MANAGED_TAGS: <<parameters.enable-ecs-managed-tags>>
         ECS_PARAM_PROPAGATE_TAGS: <<parameters.propagate-tags>>
         ECS_PARAM_CAPACITY_PROVIDER_STRATEGY: <<parameters.capacity-provider-strategy>>
+        ECS_PARAM_PROFILE_NAME: <<parameters.profile-name>>

--- a/src/commands/update-service.yml
+++ b/src/commands/update-service.yml
@@ -128,6 +128,10 @@ parameters:
       Values should not contain commas.
     type: string
     default: ''
+  profile-name:
+    description: AWS profile name to be configured.
+    type: string
+    default: ''
 steps:
   - unless:
       condition: << parameters.skip-task-definition-registration >>
@@ -145,7 +149,8 @@ steps:
               TASK_DEFINITION_ARN=$(aws ecs describe-task-definition \
                 --task-definition << parameters.family >> \
                 --output text \
-                --query 'taskDefinition.taskDefinitionArn')
+                --query 'taskDefinition.taskDefinitionArn' \
+                --profile=<< parameters.profile-name >>)
               echo "export CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN='${TASK_DEFINITION_ARN}'" >> $BASH_ENV
   - when:
       condition: << parameters.task-definition-tags >>
@@ -155,7 +160,8 @@ steps:
             command: >
               aws ecs tag-resource \
                 --resource-arn ${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN} \
-                --tags <<parameters.task-definition-tags>>
+                --tags <<parameters.task-definition-tags>> \
+                --profile=<< parameters.profile-name >>
   - when:
       condition:
         equal:
@@ -172,6 +178,7 @@ steps:
               ECS_PARAM_CD_LOAD_BALANCED_CONTAINER_NAME: <<parameters.codedeploy-load-balanced-container-name>>
               ECS_PARAM_CD_LOAD_BALANCED_CONTAINER_PORT: <<parameters.codedeploy-load-balanced-container-port>>
               ECS_PARAM_VERIFY_REV_DEPLOY: <<parameters.verify-revision-is-deployed>>
+              ECS_PARAM_PROFILE_NAME: <<parameters.profile-name>>
 
       no_output_timeout: << parameters.verification-timeout >>
   - when:
@@ -188,6 +195,7 @@ steps:
               ECS_PARAM_FAMILY: <<parameters.family>>
               ECS_PARAM_FORCE_NEW_DEPLOY: <<parameters.force-new-deployment>>
               ECS_PARAM_CLUSTER_NAME: << parameters.cluster-name >>
+              ECS_PARAM_PROFILE_NAME: <<parameters.profile-name>>
 
   - when:
       condition:
@@ -205,3 +213,4 @@ steps:
             max-poll-attempts: << parameters.max-poll-attempts >>
             poll-interval: << parameters.poll-interval >>
             fail-on-verification-timeout: << parameters.fail-on-verification-timeout >>
+            profile-name: << parameters.profile-name >>

--- a/src/commands/update-task-definition-from-json.yml
+++ b/src/commands/update-task-definition-from-json.yml
@@ -4,9 +4,14 @@ parameters:
     description: |
       Location of your .json task definition file (relative or absolute).
     type: string
+  profile-name:
+    description: AWS profile name to be configured.
+    type: string
+    default: ''
 steps:
   - run:
       name: Register new task definition
       command: <<include(scripts/update-task-definition-from-json.sh)>>
       environment:
         ECS_PARAM_TASK_DEFINITION_JSON: <<parameters.task-definition-json>>
+        ECS_PARAM_PROFILE_NAME: <<parameters.profile-name>>

--- a/src/commands/update-task-definition.yml
+++ b/src/commands/update-task-definition.yml
@@ -32,6 +32,10 @@ parameters:
       Values should not contain commas.
     type: string
     default: ''
+  profile-name:
+    description: AWS profile name to be configured.
+    type: string
+    default: ''
 steps:
   - run:
       name: Retrieve previous task definition and prepare new task definition values
@@ -42,6 +46,7 @@ steps:
         ECS_PARAM_CONTAINER_ENV_VAR_UPDATES: <<parameters.container-env-var-updates>>
         ECS_SCRIPT_UPDATE_CONTAINER_DEFS: <<include(scripts/update_container_defs.py)>>
         ECS_SCRIPT_GET_TASK_DFN_VAL: <<include(scripts/get_task_dfn_val.py)>>
+        ECS_PARAM_PROFILE_NAME: <<parameters.profile-name>>
 
 
   - run:
@@ -49,3 +54,4 @@ steps:
       command: <<include(scripts/register-new-task-def.sh)>>
       environment:
         ECS_PARAM_FAMILY: <<parameters.family>>
+        ECS_PARAM_PROFILE_NAME: <<parameters.profile-name>>

--- a/src/commands/verify-revision-is-deployed.yml
+++ b/src/commands/verify-revision-is-deployed.yml
@@ -30,6 +30,10 @@ parameters:
       Whether to exit with an error if the verification of the deployment status does not complete within the number of polling attempts.
     type: boolean
     default: true
+  profile-name:
+    description: AWS profile name to be configured.
+    type: string
+    default: ''
 steps:
   - run:
       name: Verify that the revision is deployed and older revisions are stopped
@@ -44,3 +48,4 @@ steps:
         ECS_PARAM_CLUSTER_NAME: <<parameters.cluster-name>>
         ECS_PARAM_POLL_INTERVAL: <<parameters.poll-interval>>
         ECS_PARAM_FAIL_ON_VERIFY_TIMEOUT: <<parameters.fail-on-verification-timeout>>
+        ECS_PARAM_PROFILE_NAME: <<parameters.profile-name>>

--- a/src/examples/verify-revision-deplopyment.yml
+++ b/src/examples/verify-revision-deplopyment.yml
@@ -10,7 +10,7 @@ usage:
         - image: cimg/python:3.9.1
       steps:
         - aws-cli/setup:
-            # If these values have not been modified from their default, they do not need to be included.
+             # If they are included, they configure the "default" profile, which is specified below.
             aws-access-key-id: AWS_SECRET_ACCESS_KEY
             aws-secret-access-key: AWS_DEFAULT_REGION
             aws-region: AWS_DEFAULT_REGION
@@ -20,7 +20,8 @@ usage:
               TASK_DEFINITION_ARN=$(aws ecs describe-task-definition \
                   --task-definition ${MY_APP_PREFIX}-service \
                   --output text \
-                  --query 'taskDefinition.taskDefinitionArn')
+                  --query 'taskDefinition.taskDefinitionArn' \
+                  --profile default)
               echo "export TASK_DEFINITION_ARN='${TASK_DEFINITION_ARN}'" >>
               $BASH_ENV
         - aws-ecs/verify-revision-is-deployed:

--- a/src/jobs/deploy-service-update.yml
+++ b/src/jobs/deploy-service-update.yml
@@ -25,7 +25,7 @@ parameters:
   profile-name:
     description: AWS profile name to be configured.
     type: string
-    default: default
+    default: ''
   family:
     description: Name of the task definition's family.
     type: string

--- a/src/jobs/deploy-service-update.yml
+++ b/src/jobs/deploy-service-update.yml
@@ -22,6 +22,10 @@ parameters:
     description: AWS region to operate in. Set this to the name of the environment variable you will use to hold this value, i.e. AWS_DEFAULT_REGION.
     type: env_var_name
     default: AWS_DEFAULT_REGION
+  profile-name:
+    description: AWS profile name to be configured.
+    type: string
+    default: default
   family:
     description: Name of the task definition's family.
     type: string
@@ -180,6 +184,7 @@ steps:
       aws-access-key-id: << parameters.aws-access-key-id >>
       aws-secret-access-key: << parameters.aws-secret-access-key >>
       aws-region: << parameters.aws-region >>
+      profile-name: << parameters.profile-name >>
   - update-service:
       family: << parameters.family >>
       cluster-name: << parameters.cluster-name >>
@@ -199,3 +204,4 @@ steps:
       skip-task-definition-registration: << parameters.skip-task-definition-registration >>
       task-definition-tags: << parameters.task-definition-tags >>
       verification-timeout: << parameters.verification-timeout >>
+      profile-name: << parameters.profile-name >>

--- a/src/jobs/run-task.yml
+++ b/src/jobs/run-task.yml
@@ -25,7 +25,7 @@ parameters:
   profile-name:
     description: AWS profile name to be configured.
     type: string
-    default: default
+    default: ''
   cluster:
     description: The name or ARN of the cluster on which to run the task.
     type: string

--- a/src/jobs/run-task.yml
+++ b/src/jobs/run-task.yml
@@ -22,6 +22,10 @@ parameters:
     description: AWS region to operate in. Set this to the name of the environment variable you will use to hold this value, i.e. AWS_DEFAULT_REGION.
     type: env_var_name
     default: AWS_DEFAULT_REGION
+  profile-name:
+    description: AWS profile name to be configured.
+    type: string
+    default: default
   cluster:
     description: The name or ARN of the cluster on which to run the task.
     type: string
@@ -153,6 +157,7 @@ steps:
       aws-access-key-id: << parameters.aws-access-key-id >>
       aws-secret-access-key: << parameters.aws-secret-access-key >>
       aws-region: << parameters.aws-region >>
+      profile-name: << parameters.profile-name >>
   - run-task:
       cluster: << parameters.cluster >>
       task-definition: << parameters.task-definition >>
@@ -172,3 +177,4 @@ steps:
       enable-ecs-managed-tags: << parameters.enable-ecs-managed-tags >>
       propagate-tags: << parameters.propagate-tags >>
       capacity-provider-strategy: << parameters.capacity-provider-strategy >>
+      profile-name: << parameters.profile-name >>

--- a/src/jobs/update-task-definition-from-json.yml
+++ b/src/jobs/update-task-definition-from-json.yml
@@ -21,6 +21,10 @@ parameters:
     description: AWS region to operate in. Set this to the name of the environment variable you will use to hold this value, i.e. AWS_DEFAULT_REGION.
     type: env_var_name
     default: AWS_DEFAULT_REGION
+  profile-name:
+    description: AWS profile name to be configured.
+    type: string
+    default: default
   task-definition-json:
     description: |
       Location of your .json task definition file (relative or absolute).
@@ -30,5 +34,7 @@ steps:
       aws-access-key-id: << parameters.aws-access-key-id >>
       aws-secret-access-key: << parameters.aws-secret-access-key >>
       aws-region: << parameters.aws-region >>
+      profile-name: << parameters.profile-name >>
   - update-task-definition-from-json:
       task-definition-json: << parameters.task-definition-json >>
+      profile-name: << parameters.profile-name >>

--- a/src/jobs/update-task-definition-from-json.yml
+++ b/src/jobs/update-task-definition-from-json.yml
@@ -24,7 +24,7 @@ parameters:
   profile-name:
     description: AWS profile name to be configured.
     type: string
-    default: default
+    default: ''
   task-definition-json:
     description: |
       Location of your .json task definition file (relative or absolute).

--- a/src/jobs/update-task-definition.yml
+++ b/src/jobs/update-task-definition.yml
@@ -22,6 +22,10 @@ parameters:
     description: AWS region to operate in. Set this to the name of the environment variable you will use to hold this value, i.e. AWS_DEFAULT_REGION.
     type: env_var_name
     default: AWS_DEFAULT_REGION
+  profile-name:
+    description: AWS profile name to be configured.
+    type: string
+    default: default
   family:
     description: Name of the task definition's family.
     type: string
@@ -66,7 +70,9 @@ steps:
       aws-access-key-id: << parameters.aws-access-key-id >>
       aws-secret-access-key: << parameters.aws-secret-access-key >>
       aws-region: << parameters.aws-region >>
+      profile-name: << parameters.profile-name >>
   - update-task-definition:
       family: << parameters.family >>
       container-image-name-updates: << parameters.container-image-name-updates >>
       container-env-var-updates: << parameters.container-env-var-updates >>
+      profile-name: << parameters.profile-name >>

--- a/src/jobs/update-task-definition.yml
+++ b/src/jobs/update-task-definition.yml
@@ -25,7 +25,7 @@ parameters:
   profile-name:
     description: AWS profile name to be configured.
     type: string
-    default: default
+    default: ''
   family:
     description: Name of the task definition's family.
     type: string

--- a/src/scripts/get-prev-task.sh
+++ b/src/scripts/get-prev-task.sh
@@ -6,7 +6,7 @@ ECS_PARAM_CONTAINER_IMAGE_NAME_UPDATES=$(eval echo "$ECS_PARAM_CONTAINER_IMAGE_N
 ECS_PARAM_CONTAINER_ENV_VAR_UPDATES=$(eval echo "$ECS_PARAM_CONTAINER_ENV_VAR_UPDATES")
 
 # shellcheck disable=SC2034
-PREVIOUS_TASK_DEFINITION=$(aws ecs describe-task-definition --task-definition "$ECS_PARAM_FAMILY" --include TAGS)
+PREVIOUS_TASK_DEFINITION=$(aws ecs describe-task-definition --task-definition "$ECS_PARAM_FAMILY" --include TAGS --profile="$ECS_PARAM_PROFILE_NAME")
 
 
 

--- a/src/scripts/get-prev-task.sh
+++ b/src/scripts/get-prev-task.sh
@@ -4,9 +4,13 @@ set -o noglob
 ECS_PARAM_FAMILY=$(eval echo "$ECS_PARAM_FAMILY")
 ECS_PARAM_CONTAINER_IMAGE_NAME_UPDATES=$(eval echo "$ECS_PARAM_CONTAINER_IMAGE_NAME_UPDATES")
 ECS_PARAM_CONTAINER_ENV_VAR_UPDATES=$(eval echo "$ECS_PARAM_CONTAINER_ENV_VAR_UPDATES")
+ECS_PARAM_PROFILE_NAME=$(eval echo "$ECS_PARAM_PROFILE_NAME")
 
+if [ -n "${ECS_PARAM_PROFILE_NAME}" ]; then
+    set -- "$@" --profile "${ECS_PARAM_PROFILE_NAME}"   
+fi
 # shellcheck disable=SC2034
-PREVIOUS_TASK_DEFINITION=$(aws ecs describe-task-definition --task-definition "$ECS_PARAM_FAMILY" --include TAGS --profile="$ECS_PARAM_PROFILE_NAME")
+PREVIOUS_TASK_DEFINITION=$(aws ecs describe-task-definition --task-definition "$ECS_PARAM_FAMILY" --include TAGS "$@")
 
 
 

--- a/src/scripts/register-new-task-def.sh
+++ b/src/scripts/register-new-task-def.sh
@@ -56,7 +56,8 @@ REVISION=$(aws ecs register-task-definition \
     --container-definitions "${CCI_ORB_AWS_ECS_CONTAINER_DEFS}" \
     "$@" \
     --output text \
-    --query 'taskDefinition.taskDefinitionArn')
+    --query 'taskDefinition.taskDefinitionArn'\
+    --profile="$ECS_PARAM_PROFILE_NAME")
 echo "Registered task definition: ${REVISION}"
 
 echo "export CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN='${REVISION}'" >> "$BASH_ENV"

--- a/src/scripts/register-new-task-def.sh
+++ b/src/scripts/register-new-task-def.sh
@@ -2,6 +2,7 @@ set -o noglob
 
 # These variables are evaluated so the config file may contain and pass in environment variables to the parameters.
 ECS_PARAM_FAMILY=$(eval echo "$ECS_PARAM_FAMILY")
+ECS_PARAM_PROFILE_NAME=$(eval echo "$ECS_PARAM_PROFILE_NAME")
 
 if [ -n "${CCI_ORB_AWS_ECS_TASK_ROLE}" ]; then
     set -- "$@" --task-role-arn "${CCI_ORB_AWS_ECS_TASK_ROLE}"
@@ -51,13 +52,16 @@ if [ -n "${CCI_ORB_AWS_ECS_PROXY_CONFIGURATION}" ] && [ "${CCI_ORB_AWS_ECS_PROXY
     set -- "$@" --proxy-configuration "${CCI_ORB_AWS_ECS_PROXY_CONFIGURATION}"
 fi
 
+if [ -n "${ECS_PARAM_PROFILE_NAME}" ]; then
+    set -- "$@" --profile "${ECS_PARAM_PROFILE_NAME}"
+fi
+
 REVISION=$(aws ecs register-task-definition \
     --family "$ECS_PARAM_FAMILY" \
     --container-definitions "${CCI_ORB_AWS_ECS_CONTAINER_DEFS}" \
     "$@" \
     --output text \
-    --query 'taskDefinition.taskDefinitionArn'\
-    --profile="$ECS_PARAM_PROFILE_NAME")
+    --query 'taskDefinition.taskDefinitionArn')
 echo "Registered task definition: ${REVISION}"
 
 echo "export CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN='${REVISION}'" >> "$BASH_ENV"

--- a/src/scripts/run-task.sh
+++ b/src/scripts/run-task.sh
@@ -1,6 +1,7 @@
 # These variables are evaluated so the config file may contain and pass in environment variables to the parameters.
 ECS_PARAM_CLUSTER_NAME=$(eval echo "$ECS_PARAM_CLUSTER_NAME")
 ECS_PARAM_TASK_DEF=$(eval echo "$ECS_PARAM_TASK_DEF")
+ECS_PARAM_PROFILE_NAME=$(eval echo "$ECS_PARAM_PROFILE_NAME")
 
 set -o noglob
 if [ -n "$ECS_PARAM_PLATFORM_VERSION" ]; then

--- a/src/scripts/run-task.sh
+++ b/src/scripts/run-task.sh
@@ -68,6 +68,10 @@ if [ -n "$ECS_PARAM_LAUNCH_TYPE" ]; then
     fi
 fi
 
+if [ -n "${ECS_PARAM_PROFILE_NAME}" ]; then
+    set -- "$@" --profile "${ECS_PARAM_PROFILE_NAME}"
+fi
+
 echo "Setting --count"
 set -- "$@" --count "$ECS_PARAM_COUNT"
 echo "Setting --task-definition"

--- a/src/scripts/update-service-via-task-def.sh
+++ b/src/scripts/update-service-via-task-def.sh
@@ -19,5 +19,6 @@ DEPLOYED_REVISION=$(aws ecs update-service \
     --task-definition "${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN}" \
     --output text \
     --query service.taskDefinition \
+    -profile="$ECS_PARAM_PROFILE_NAME" \
     "$@")
 echo "export CCI_ORB_AWS_ECS_DEPLOYED_REVISION='${DEPLOYED_REVISION}'" >> "$BASH_ENV"

--- a/src/scripts/update-service-via-task-def.sh
+++ b/src/scripts/update-service-via-task-def.sh
@@ -4,6 +4,7 @@ set -o noglob
 ECS_PARAM_FAMILY=$(eval echo "$ECS_PARAM_FAMILY")
 ECS_PARAM_CLUSTER_NAME=$(eval echo "$ECS_PARAM_CLUSTER_NAME")
 ECS_PARAM_SERVICE_NAME=$(eval echo "$ECS_PARAM_SERVICE_NAME")
+ECS_PARAM_PROFILE_NAME=$(eval echo "$ECS_PARAM_PROFILE_NAME")
 
 if [ -z "${ECS_PARAM_SERVICE_NAME}" ]; then
     ECS_PARAM_SERVICE_NAME="$ECS_PARAM_FAMILY"
@@ -13,12 +14,14 @@ if [ "$ECS_PARAM_FORCE_NEW_DEPLOY" == "1" ]; then
     set -- "$@" --force-new-deployment
 fi
 
+if [ -n "${ECS_PARAM_PROFILE_NAME}" ]; then
+    set -- "$@" --profile "${ECS_PARAM_PROFILE_NAME}"   
+fi
 DEPLOYED_REVISION=$(aws ecs update-service \
     --cluster "$ECS_PARAM_CLUSTER_NAME" \
     --service "${ECS_PARAM_SERVICE_NAME}" \
     --task-definition "${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN}" \
     --output text \
     --query service.taskDefinition \
-    -profile="$ECS_PARAM_PROFILE_NAME" \
     "$@")
 echo "export CCI_ORB_AWS_ECS_DEPLOYED_REVISION='${DEPLOYED_REVISION}'" >> "$BASH_ENV"

--- a/src/scripts/update-task-definition-from-json.sh
+++ b/src/scripts/update-task-definition-from-json.sh
@@ -5,7 +5,8 @@ fi
 REVISION=$(aws ecs register-task-definition \
     --cli-input-json file://"${ECS_PARAM_TASK_DEFINITION_JSON}" \
     --output text \
-    --query 'taskDefinition.taskDefinitionArn')
+    --query 'taskDefinition.taskDefinitionArn' \
+    --profile="$ECS_PARAM_PROFILE_NAME")
 echo "Registered task definition: ${REVISION}"
 
 echo "export CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN='${REVISION}'" >> "$BASH_ENV"

--- a/src/scripts/update-task-definition-from-json.sh
+++ b/src/scripts/update-task-definition-from-json.sh
@@ -1,12 +1,17 @@
+ECS_PARAM_PROFILE_NAME=$(eval echo "$ECS_PARAM_PROFILE_NAME")
+
 if [ "${ECS_PARAM_TASK_DEFINITION_JSON:0:1}" != "/" ]; then
     ECS_PARAM_TASK_DEFINITION_JSON="$(pwd)/${ECS_PARAM_TASK_DEFINITION_JSON}"
 fi
 
+if [ -n "${ECS_PARAM_PROFILE_NAME}" ]; then
+    set -- "$@" --profile "${ECS_PARAM_PROFILE_NAME}"   
+fi
 REVISION=$(aws ecs register-task-definition \
     --cli-input-json file://"${ECS_PARAM_TASK_DEFINITION_JSON}" \
     --output text \
     --query 'taskDefinition.taskDefinitionArn' \
-    --profile="$ECS_PARAM_PROFILE_NAME")
+    "$@")
 echo "Registered task definition: ${REVISION}"
 
 echo "export CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN='${REVISION}'" >> "$BASH_ENV"

--- a/src/scripts/verify-revision-is-deployed.sh
+++ b/src/scripts/verify-revision-is-deployed.sh
@@ -3,6 +3,7 @@ ECS_PARAM_FAMILY=$(eval echo "$ECS_PARAM_FAMILY")
 ECS_PARAM_SERVICE_NAME=$(eval echo "$ECS_PARAM_SERVICE_NAME")
 ECS_PARAM_CLUSTER_NAME=$(eval echo "$ECS_PARAM_CLUSTER_NAME")
 ECS_PARAM_TASK_DEF_ARN=$(eval echo "$ECS_PARAM_TASK_DEF_ARN")
+ECS_PARAM_PROFILE_NAME=$(eval echo "$ECS_PARAM_PROFILE_NAME")
 
 if [ "$ECS_PARAM_TASK_DEF_ARN" = "" ]; then
     echo "Invalid task-definition-arn parameter value: $ECS_PARAM_TASK_DEF_ARN"
@@ -14,32 +15,35 @@ if [ -z "${ECS_PARAM_SERVICE_NAME}" ]; then
     ECS_PARAM_SERVICE_NAME="$ECS_PARAM_FAMILY"
 fi
 
-
 echo "Verifying that $ECS_PARAM_TASK_DEF_ARN is deployed.."
 
 attempt=0
 
 while [ "$attempt" -lt "$ECS_PARAM_MAX_POLL_ATTEMPTS" ]
 
-do
+do  
+    if [ -n "${ECS_PARAM_PROFILE_NAME}" ]; then
+        set -- "$@" --profile="${ECS_PARAM_PROFILE_NAME}"   
+    fi
+
     DEPLOYMENTS=$(aws ecs describe-services \
         --cluster "$ECS_PARAM_CLUSTER_NAME" \
         --services "${ECS_PARAM_SERVICE_NAME}" \
         --output text \
-         --query 'services[0].deployments[].[taskDefinition, status]' \
-        --profile="$ECS_PARAM_PROFILE_NAME")
+        --query 'services[0].deployments[].[taskDefinition, status]' \
+        "$@")
     NUM_DEPLOYMENTS=$(aws ecs describe-services \
         --cluster "$ECS_PARAM_CLUSTER_NAME" \
         --services "${ECS_PARAM_SERVICE_NAME}" \
         --output text \
         --query 'length(services[0].deployments)' \
-        --profile="$ECS_PARAM_PROFILE_NAME")
+        "$@")
     TARGET_REVISION=$(aws ecs describe-services \
         --cluster "$ECS_PARAM_CLUSTER_NAME" \
         --services "${ECS_PARAM_SERVICE_NAME}" \
         --output text \
         --query "services[0].deployments[?taskDefinition==\`$ECS_PARAM_TASK_DEF_ARN\` && runningCount == desiredCount && (status == \`PRIMARY\` || status == \`ACTIVE\`)][taskDefinition]" \
-        --profile="$ECS_PARAM_PROFILE_NAME")
+        "$@")
     echo "Current deployments: $DEPLOYMENTS"
     if [ "$NUM_DEPLOYMENTS" = "1" ] && [ "$TARGET_REVISION" = "$ECS_PARAM_TASK_DEF_ARN" ]; then
         echo "The task definition revision $TARGET_REVISION is the only deployment for the service and has attained the desired running task count."

--- a/src/scripts/verify-revision-is-deployed.sh
+++ b/src/scripts/verify-revision-is-deployed.sh
@@ -26,17 +26,20 @@ do
         --cluster "$ECS_PARAM_CLUSTER_NAME" \
         --services "${ECS_PARAM_SERVICE_NAME}" \
         --output text \
-        --query 'services[0].deployments[].[taskDefinition, status]')
+         --query 'services[0].deployments[].[taskDefinition, status]' \
+        --profile="$ECS_PARAM_PROFILE_NAME")
     NUM_DEPLOYMENTS=$(aws ecs describe-services \
         --cluster "$ECS_PARAM_CLUSTER_NAME" \
         --services "${ECS_PARAM_SERVICE_NAME}" \
         --output text \
-        --query 'length(services[0].deployments)')
+        --query 'length(services[0].deployments)' \
+        --profile="$ECS_PARAM_PROFILE_NAME")
     TARGET_REVISION=$(aws ecs describe-services \
         --cluster "$ECS_PARAM_CLUSTER_NAME" \
         --services "${ECS_PARAM_SERVICE_NAME}" \
         --output text \
-        --query "services[0].deployments[?taskDefinition==\`$ECS_PARAM_TASK_DEF_ARN\` && runningCount == desiredCount && (status == \`PRIMARY\` || status == \`ACTIVE\`)][taskDefinition]")
+        --query "services[0].deployments[?taskDefinition==\`$ECS_PARAM_TASK_DEF_ARN\` && runningCount == desiredCount && (status == \`PRIMARY\` || status == \`ACTIVE\`)][taskDefinition]" \
+        --profile="$ECS_PARAM_PROFILE_NAME")
     echo "Current deployments: $DEPLOYMENTS"
     if [ "$NUM_DEPLOYMENTS" = "1" ] && [ "$TARGET_REVISION" = "$ECS_PARAM_TASK_DEF_ARN" ]; then
         echo "The task definition revision $TARGET_REVISION is the only deployment for the service and has attained the desired running task count."


### PR DESCRIPTION
This PR adds the `profile-name`  parameter to every job and command in this orb. It enables the use of a name profile defined in the `~/.aws/credentials` file in `Linux` and `Mac` or `%USERPROFILE%\.aws\credentials` in `Windows`  with each command. 