### PR TITLE
feat: Added previous-revision-number parameter

### DIFF
--- a/src/commands/update-service.yml
+++ b/src/commands/update-service.yml
@@ -194,7 +194,7 @@ steps:
               ECS_PARAM_SERVICE_NAME: <<parameters.service-name>>
               ECS_PARAM_FAMILY: <<parameters.family>>
               ECS_PARAM_FORCE_NEW_DEPLOY: <<parameters.force-new-deployment>>
-              ECS_PARAM_CLUSTER_NAME: << parameters.cluster-name >>
+              ECS_PARAM_CLUSTER_NAME: <<parameters.cluster-name>>
               ECS_PARAM_PROFILE_NAME: <<parameters.profile-name>>
 
   - when:

--- a/src/commands/update-task-definition.yml
+++ b/src/commands/update-task-definition.yml
@@ -36,6 +36,10 @@ parameters:
     description: AWS profile name to be configured.
     type: string
     default: ''
+  previous-revision-number:
+    description: Optional previous task's revision number
+    type: string
+    default: ''
 steps:
   - run:
       name: Retrieve previous task definition and prepare new task definition values
@@ -47,8 +51,7 @@ steps:
         ECS_SCRIPT_UPDATE_CONTAINER_DEFS: <<include(scripts/update_container_defs.py)>>
         ECS_SCRIPT_GET_TASK_DFN_VAL: <<include(scripts/get_task_dfn_val.py)>>
         ECS_PARAM_PROFILE_NAME: <<parameters.profile-name>>
-
-
+        ECS_PARAM_PREVIOUS_REVISION_NUMBER: <<parameters.previous-revision-number>>
   - run:
       name: Register new task definition
       command: <<include(scripts/register-new-task-def.sh)>>

--- a/src/scripts/get-prev-task.sh
+++ b/src/scripts/get-prev-task.sh
@@ -9,10 +9,15 @@ ECS_PARAM_PROFILE_NAME=$(eval echo "$ECS_PARAM_PROFILE_NAME")
 if [ -n "${ECS_PARAM_PROFILE_NAME}" ]; then
     set -- "$@" --profile "${ECS_PARAM_PROFILE_NAME}"   
 fi
+
+if [ -z "${ECS_PARAM_PREVIOUS_REVISION}" ]; then
+  ECS_TASK_DEFINITION_NAME="$ECS_PARAM_FAMILY"
+else
+  ECS_TASK_DEFINITION_NAME="$ECS_PARAM_FAMILY:$ECS_PARAM_PREVIOUS_REVISION_NUMBER"
+fi
+
 # shellcheck disable=SC2034
-PREVIOUS_TASK_DEFINITION=$(aws ecs describe-task-definition --task-definition "$ECS_PARAM_FAMILY" --include TAGS "$@")
-
-
+PREVIOUS_TASK_DEFINITION=$(aws ecs describe-task-definition --task-definition "${ECS_TASK_DEFINITION_NAME}" --include TAGS "$@")
 
 # Prepare script for updating container definitions
 


### PR DESCRIPTION
This PR adds the `previous-revision-number` parameter to the `update-task-definition` command. Previously, users were only able to retrieve previous tasks based families. This enables users to retrieve task definitions within the same family. 