### PR TITLE
feat: Added enable-circuit-breaker parameter

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -399,6 +399,8 @@ workflows:
           cluster-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
           # test skipping registration of a new task definition
           skip-task-definition-registration: true
+          # test the enable-circuit-breaker flag
+          enable-circuit-breaker: true
           verify-revision-is-deployed: true
           max-poll-attempts: 40
           poll-interval: 10

--- a/src/commands/update-service.yml
+++ b/src/commands/update-service.yml
@@ -75,6 +75,12 @@ parameters:
       Not applicable to ECS services that are of the Blue/Green Deployment type.
     type: boolean
     default: false
+  enable-circuit-breaker:
+    description: |
+      Determines whether a service deployment will fail if the service can't reach a steady state.
+      The deployment circuit breaker can only be used for services using the rolling update (ECS) deployment type.
+    type: boolean
+    default: false
   verify-revision-is-deployed:
     description: |
       Runs the verify-revision-is-deployed Orb command to verify that the revision has been deployed and is the only deployed revision for the service.
@@ -132,6 +138,7 @@ parameters:
     description: AWS profile name to be configured.
     type: string
     default: ''
+
 steps:
   - unless:
       condition: << parameters.skip-task-definition-registration >>
@@ -194,8 +201,9 @@ steps:
               ECS_PARAM_SERVICE_NAME: <<parameters.service-name>>
               ECS_PARAM_FAMILY: <<parameters.family>>
               ECS_PARAM_FORCE_NEW_DEPLOY: <<parameters.force-new-deployment>>
-              ECS_PARAM_CLUSTER_NAME: << parameters.cluster-name >>
+              ECS_PARAM_CLUSTER_NAME: <<parameters.cluster-name>>
               ECS_PARAM_PROFILE_NAME: <<parameters.profile-name>>
+              ECS_PARAM_ENABLE_CIRCUIT_BREAKER: <<parameters.enable-circuit-breaker>>
 
   - when:
       condition:

--- a/src/commands/update-task-definition.yml
+++ b/src/commands/update-task-definition.yml
@@ -36,6 +36,10 @@ parameters:
     description: AWS profile name to be configured.
     type: string
     default: ''
+  previous-revision-number:
+    description: Optional previous task's revision number
+    type: string
+    default: ''
 steps:
   - run:
       name: Retrieve previous task definition and prepare new task definition values
@@ -47,8 +51,7 @@ steps:
         ECS_SCRIPT_UPDATE_CONTAINER_DEFS: <<include(scripts/update_container_defs.py)>>
         ECS_SCRIPT_GET_TASK_DFN_VAL: <<include(scripts/get_task_dfn_val.py)>>
         ECS_PARAM_PROFILE_NAME: <<parameters.profile-name>>
-
-
+        ECS_PARAM_PREVIOUS_REVISION_NUMBER: <<parameters.previous-revision-number>>
   - run:
       name: Register new task definition
       command: <<include(scripts/register-new-task-def.sh)>>

--- a/src/jobs/deploy-service-update.yml
+++ b/src/jobs/deploy-service-update.yml
@@ -119,6 +119,12 @@ parameters:
       Not applicable to ECS services that are of the Blue/Green Deployment type.
     type: boolean
     default: false
+  enable-circuit-breaker:
+    description: |
+      Determines whether a service deployment will fail if the service can’t reach a steady state.
+      The deployment circuit breaker can only be used for services using the rolling update (ECS ) deployment type.
+    type: boolean
+    default: false
   verify-revision-is-deployed:
     description: |
       Runs the verify-revision-is-deployed Orb command to verify that
@@ -190,6 +196,7 @@ steps:
       cluster-name: << parameters.cluster-name >>
       service-name: << parameters.service-name >>
       deployment-controller: << parameters.deployment-controller >>
+      enable-circuit-breaker: << parameters.enable-circuit-breaker >>
       codedeploy-application-name: << parameters.codedeploy-application-name >>
       codedeploy-deployment-group-name: << parameters.codedeploy-deployment-group-name >>
       codedeploy-load-balanced-container-name: << parameters.codedeploy-load-balanced-container-name >>

--- a/src/scripts/get-prev-task.sh
+++ b/src/scripts/get-prev-task.sh
@@ -9,10 +9,15 @@ ECS_PARAM_PROFILE_NAME=$(eval echo "$ECS_PARAM_PROFILE_NAME")
 if [ -n "${ECS_PARAM_PROFILE_NAME}" ]; then
     set -- "$@" --profile "${ECS_PARAM_PROFILE_NAME}"   
 fi
+
+if [ -z "${ECS_PARAM_PREVIOUS_REVISION}" ]; then
+  ECS_TASK_DEFINITION_NAME="$ECS_PARAM_FAMILY"
+else
+  ECS_TASK_DEFINITION_NAME="$ECS_PARAM_FAMILY:$ECS_PARAM_PREVIOUS_REVISION_NUMBER"
+fi
+
 # shellcheck disable=SC2034
-PREVIOUS_TASK_DEFINITION=$(aws ecs describe-task-definition --task-definition "$ECS_PARAM_FAMILY" --include TAGS "$@")
-
-
+PREVIOUS_TASK_DEFINITION=$(aws ecs describe-task-definition --task-definition "${ECS_TASK_DEFINITION_NAME}" --include TAGS "$@")
 
 # Prepare script for updating container definitions
 

--- a/src/scripts/update-service-via-task-def.sh
+++ b/src/scripts/update-service-via-task-def.sh
@@ -17,6 +17,11 @@ fi
 if [ -n "${ECS_PARAM_PROFILE_NAME}" ]; then
     set -- "$@" --profile "${ECS_PARAM_PROFILE_NAME}"   
 fi
+
+if [ "$ECS_PARAM_ENABLE_CIRCUIT_BREAKER" == "1" ]; then
+    set -- "$@" --deployment-configuration "deploymentCircuitBreaker={enable=true,rollback=true}"
+fi
+
 DEPLOYED_REVISION=$(aws ecs update-service \
     --cluster "$ECS_PARAM_CLUSTER_NAME" \
     --service "${ECS_PARAM_SERVICE_NAME}" \


### PR DESCRIPTION
This PR adds the `enable-circuit-breaker` parameter to the `update-service` command. When set to true, it enables users to  automatically roll back failing service deployments without the need to do it manually.