### PR TITLE
feat: Added enable-circuit-breaker parameter for Code Deploy

### DIFF
--- a/src/commands/update-service.yml
+++ b/src/commands/update-service.yml
@@ -78,7 +78,7 @@ parameters:
   enable-circuit-breaker:
     description: |
       Determines whether a service deployment will fail if the service can't reach a steady state.
-      The deployment circuit breaker can only be used for services using the rolling update (ECS) deployment type.
+      To use the deployment circuit breaker for CodeDeploy services, the verify-revision-is-deployed parameter must be set to true.
     type: boolean
     default: false
   verify-revision-is-deployed:
@@ -186,6 +186,7 @@ steps:
               ECS_PARAM_CD_LOAD_BALANCED_CONTAINER_PORT: <<parameters.codedeploy-load-balanced-container-port>>
               ECS_PARAM_VERIFY_REV_DEPLOY: <<parameters.verify-revision-is-deployed>>
               ECS_PARAM_PROFILE_NAME: <<parameters.profile-name>>
+              ECS_PARAM_ENABLE_CIRCUIT_BREAKER: <<parameters.enable-circuit-breaker>>
 
       no_output_timeout: << parameters.verification-timeout >>
   - when:

--- a/src/scripts/update-bluegreen-service-via-task-def.sh
+++ b/src/scripts/update-bluegreen-service-via-task-def.sh
@@ -5,8 +5,12 @@ ECS_PARAM_CD_APP_NAME=$(eval echo "$ECS_PARAM_CD_APP_NAME")
 ECS_PARAM_CD_DEPLOY_GROUP_NAME=$(eval echo "$ECS_PARAM_CD_DEPLOY_GROUP_NAME")
 ECS_PARAM_CD_LOAD_BALANCED_CONTAINER_NAME=$(eval echo "$ECS_PARAM_CD_LOAD_BALANCED_CONTAINER_NAME")
 
-
 DEPLOYED_REVISION="${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN}"
+
+if [ "$ECS_PARAM_ENABLE_CIRCUIT_BREAKER" == "1" ] && [ "$ECS_PARAM_VERIFY_REV_DEPLOY" == "0" ]; then
+    echo "enable-circuit-breaker is set to true, but verify-revision-deploy is set to false.  verfiy-revision-deploy is must be set to true to use enable-circuit-breaker."
+    exit 1
+fi
 
 DEPLOYMENT_ID=$(aws deploy create-deployment \
     --application-name "$ECS_PARAM_CD_APP_NAME" \

--- a/src/scripts/update-bluegreen-service-via-task-def.sh
+++ b/src/scripts/update-bluegreen-service-via-task-def.sh
@@ -20,8 +20,11 @@ if [ "$ECS_PARAM_VERIFY_REV_DEPLOY" == "1" ]; then
     echo "Waiting for deployment to succeed."
     if aws deploy wait deployment-successful --deployment-id "${DEPLOYMENT_ID}"; then
         echo "Deployment succeeded."
+    elif [ "$ECS_PARAM_ENABLE_CIRCUIT_BREAKER" == "1" ]; then
+        echo "Deployment failed. Rolling back."
+        aws deploy stop-deployment --deployment-id "${DEPLOYMENT_ID}" --auto-rollback-enabled
     else
-        echo "Deployment failed."
+        echo "Deployment failed. Exiting."
         exit 1
     fi
 fi


### PR DESCRIPTION
This PR applies the `enable-circuit-breaker` parameter to `AWS Code Deploy` deployments. In order to use this parameter, the `verify-revision-is-deployed` must be set to `true`. 

When `enable-circuit-breaker` is set to `true` it enables `Code Deploy` to roll back to a working state should updating the service fail. 