### PR TITLE
Allow variable interpolation in overrides

### DIFF
--- a/src/scripts/run-task.sh
+++ b/src/scripts/run-task.sh
@@ -18,6 +18,7 @@ if [ -n "$ECS_PARAM_GROUP" ]; then
 fi
 if [ -n "$ECS_PARAM_OVERRIDES" ]; then
     echo "Setting --overrides"
+    ECS_PARAM_OVERRIDES=$(eval echo "$ECS_PARAM_OVERRIDES")
     set -- "$@" --overrides "$ECS_PARAM_OVERRIDES"
 fi
 if [ -n "$ECS_PARAM_TAGS" ]; then

--- a/src/scripts/run-task.sh
+++ b/src/scripts/run-task.sh
@@ -2,6 +2,7 @@
 ECS_PARAM_CLUSTER_NAME=$(eval echo "$ECS_PARAM_CLUSTER_NAME")
 ECS_PARAM_TASK_DEF=$(eval echo "$ECS_PARAM_TASK_DEF")
 ECS_PARAM_PROFILE_NAME=$(eval echo "$ECS_PARAM_PROFILE_NAME")
+ECS_PARAM_OVERRIDES=$(eval echo "$ECS_PARAM_OVERRIDES")
 
 set -o noglob
 if [ -n "$ECS_PARAM_PLATFORM_VERSION" ]; then
@@ -18,7 +19,6 @@ if [ -n "$ECS_PARAM_GROUP" ]; then
 fi
 if [ -n "$ECS_PARAM_OVERRIDES" ]; then
     echo "Setting --overrides"
-    ECS_PARAM_OVERRIDES=$(eval echo "$ECS_PARAM_OVERRIDES")
     set -- "$@" --overrides "$ECS_PARAM_OVERRIDES"
 fi
 if [ -n "$ECS_PARAM_TAGS" ]; then


### PR DESCRIPTION
Fixed #160 

Add an `eval` of the `ECS_PARAM_OVERRIDES` environment variable, allowing variable interpolation in the `overrides` parameter of the `run-task` command.