### PR TITLE
feat: implement install-ecs-cli command

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -332,10 +332,29 @@ jobs:
                   -var "aws_account_id=${AWS_ACCOUNT_ID}" \
                   -var "aws_resource_prefix=<< parameters.aws-resource-name-prefix >>"
             fi
+  integration-test-ecs-cli-install:
+    parameters:
+      executor:
+        type: executor
+      version:
+        description: Select a specific version of the AWS ECS CLI. By default the latest version will be used.
+        default: latest
+        type: string
+      install-dir:
+        type: string
+        default: "/usr/local/ecs-cli"
+        description: |
+          Specify the installation directory
+    executor: <<parameters.executor>>
+    steps:
+      - install-ecs-cli:
+          version: <<parameters.version>>
+          install-dir: <<parameters.install-dir>>
 workflows:
   test-deploy:
     jobs:
       # Make sure to include "filters: *filters" in every test job you want to run as part of your deployment.
+      - 
       #################
       # Fargate
       #################

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -345,17 +345,22 @@ jobs:
         default: "/usr/local/bin/ecs-cli"
         description: |
           Specify the installation directory
+      override-installed:
+        type: boolean
+        default: false
+        description: Enable this to override the installed version and install your specified version.
     executor: <<parameters.executor>>
     steps:
       - aws-ecs/install-ecs-cli:
           version: <<parameters.version>>
           install-dir: <<parameters.install-dir>>
+          override-installed: <<parameters.override-installed>>
 workflows:
   test-deploy:
     jobs:
       # Make sure to include "filters: *filters" in every test job you want to run as part of your deployment.
       - integration-test-ecs-cli-install:
-          version: "v1.2.1"
+          version: "v1.9.0"
           matrix:
             parameters:
               executor: [linux, mac]
@@ -363,389 +368,390 @@ workflows:
       #################
       # Fargate
       #################
-#       - build-test-app:
-#           name: fargate_build-test-app
-#           docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
-#           docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}:${CIRCLE_SHA1}"
-#           context: [CPE_ORBS_AWS]
-#           filters: *filters
-#       - set-up-test-env:
-#           name: fargate_set-up-test-env
-#           filters: *filters
-#           requires:
-#             - fargate_build-test-app
-#           aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
-#           terraform-config-dir: "tests/terraform_setup/fargate"
-#           context: [CPE_ORBS_AWS]
-#       - test-service-update:
-#           name: fargate_test-update-service-command
-#           filters: *filters
-#           requires:
-#             - fargate_set-up-test-env
-#           aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
-#           family-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
-#           service-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
-#           docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
-#           docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}:${CIRCLE_SHA1}"
-#           context: [CPE_ORBS_AWS]
-#       - aws-ecs/deploy-service-update:
-#           name: fargate_test-update-service-job
-#           docker-image-for-job: cimg/python:3.10.4
-#           filters: *filters
-#           requires:
-#             - fargate_test-update-service-command
-#           aws-access-key-id: AWS_ACCESS_KEY_ID
-#           aws-region: AWS_DEFAULT_REGION
-#           profile-name: "ECS_TEST_PROFILE"
-#           family: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
-#           cluster-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
-#           container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service,name=BUILD_DATE,value=$(date)'
-#           # test the force-new-deployment flag
-#           force-new-deployment: true
-#           verify-revision-is-deployed: true
-#           max-poll-attempts: 40
-#           poll-interval: 10
-#           context: [CPE_ORBS_AWS]
-#           post-steps:
-#             - test-deployment:
-#                 service-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
-#                 cluster-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
-#       - aws-ecs/deploy-service-update:
-#           name: fargate_test-update-service-skip-registration
-#           docker-image-for-job: cimg/python:3.10.4
-#           filters: *filters
-#           requires:
-#             - fargate_test-update-service-job
-#           aws-access-key-id: AWS_ACCESS_KEY_ID
-#           aws-region: AWS_DEFAULT_REGION
-#           profile-name: "ECS_TEST_PROFILE"
-#           family: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
-#           cluster-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
-#           # test skipping registration of a new task definition
-#           skip-task-definition-registration: true
-#           # test the enable-circuit-breaker flag
-#           enable-circuit-breaker: true
-#           verify-revision-is-deployed: true
-#           max-poll-attempts: 40
-#           poll-interval: 10
-#           context: [CPE_ORBS_AWS]
-#       - tear-down-test-env:
-#           name: fargate_tear-down-test-env
-#           filters: *filters
-#           requires:
-#             - fargate_test-update-service-skip-registration
-#             - test-fargatespot
-#           aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
-#           terraform-config-dir: "tests/terraform_setup/fargate"
-#           context: [CPE_ORBS_AWS]
+      - build-test-app:
+          name: fargate_build-test-app
+          docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+          docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}:${CIRCLE_SHA1}"
+          context: [CPE_ORBS_AWS]
+          filters: *filters
+      - set-up-test-env:
+          name: fargate_set-up-test-env
+          filters: *filters
+          requires:
+            - fargate_build-test-app
+          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
+          terraform-config-dir: "tests/terraform_setup/fargate"
+          context: [CPE_ORBS_AWS]
+      - test-service-update:
+          name: fargate_test-update-service-command
+          filters: *filters
+          requires:
+            - fargate_set-up-test-env
+          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
+          family-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
+          service-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
+          docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+          docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}:${CIRCLE_SHA1}"
+          context: [CPE_ORBS_AWS]
+      - aws-ecs/deploy-service-update:
+          name: fargate_test-update-service-job
+          docker-image-for-job: cimg/python:3.10.4
+          filters: *filters
+          requires:
+            - fargate_test-update-service-command
+          aws-access-key-id: AWS_ACCESS_KEY_ID
+          aws-region: AWS_DEFAULT_REGION
+          profile-name: "ECS_TEST_PROFILE"
+          family: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
+          cluster-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
+          container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service,name=BUILD_DATE,value=$(date)'
+          # test the force-new-deployment flag
+          force-new-deployment: true
+          verify-revision-is-deployed: true
+          max-poll-attempts: 40
+          poll-interval: 10
+          context: [CPE_ORBS_AWS]
+          post-steps:
+            - test-deployment:
+                service-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
+                cluster-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
+      - aws-ecs/deploy-service-update:
+          name: fargate_test-update-service-skip-registration
+          docker-image-for-job: cimg/python:3.10.4
+          filters: *filters
+          requires:
+            - fargate_test-update-service-job
+          aws-access-key-id: AWS_ACCESS_KEY_ID
+          aws-region: AWS_DEFAULT_REGION
+          profile-name: "ECS_TEST_PROFILE"
+          family: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
+          cluster-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
+          # test skipping registration of a new task definition
+          skip-task-definition-registration: true
+          # test the enable-circuit-breaker flag
+          enable-circuit-breaker: true
+          verify-revision-is-deployed: true
+          max-poll-attempts: 40
+          poll-interval: 10
+          context: [CPE_ORBS_AWS]
+      - tear-down-test-env:
+          name: fargate_tear-down-test-env
+          filters: *filters
+          requires:
+            - fargate_test-update-service-skip-registration
+            - test-fargatespot
+          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
+          terraform-config-dir: "tests/terraform_setup/fargate"
+          context: [CPE_ORBS_AWS]
 
-#       #################
-#       # EC2
-#       #################
-#       - build-test-app:
-#           name: ec2_build-test-app
-#           docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
-#           docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}:${CIRCLE_SHA1}"
-#           context: [CPE_ORBS_AWS]
-#           filters: *filters
-#       - set-up-test-env:
-#           name: ec2_set-up-test-env
-#           filters: *filters
-#           requires:
-#             - ec2_build-test-app
-#           aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
-#           terraform-config-dir: "tests/terraform_setup/ec2"
-#           context: [CPE_ORBS_AWS]
-#       - set-up-run-task-test:
-#           name: ec2_set-up-run-task-test
-#           filters: *filters
-#           requires:
-#             - ec2_set-up-test-env
-#           family-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360"
-#           context: [CPE_ORBS_AWS]
-#       - aws-ecs/run-task:
-#           name: ec2_run-task-test
-#           filters: *filters
-#           requires:
-#             - ec2_set-up-run-task-test
-#           cluster: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
-#           aws-region: AWS_DEFAULT_REGION
-#           task-definition: "${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360"
-#           launch-type: "EC2"
-#           awsvpc: false
-#           overrides: '{"containerOverrides":[{"name": "sleep", "memory": 512}]}'
-#           context: [CPE_ORBS_AWS]
-#       - tear-down-run-task-test:
-#           name: ec2_tear-down-run-task-test
-#           filters: *filters
-#           requires:
-#             - ec2_run-task-test
-#           family-name: ${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360
-#           context: [CPE_ORBS_AWS]
+      #################
+      # EC2
+      #################
+      - build-test-app:
+          name: ec2_build-test-app
+          docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+          docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}:${CIRCLE_SHA1}"
+          context: [CPE_ORBS_AWS]
+          filters: *filters
+      - set-up-test-env:
+          name: ec2_set-up-test-env
+          filters: *filters
+          requires:
+            - ec2_build-test-app
+          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
+          terraform-config-dir: "tests/terraform_setup/ec2"
+          context: [CPE_ORBS_AWS]
+      - set-up-run-task-test:
+          name: ec2_set-up-run-task-test
+          filters: *filters
+          requires:
+            - ec2_set-up-test-env
+          family-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360"
+          context: [CPE_ORBS_AWS]
+      - aws-ecs/run-task:
+          name: ec2_run-task-test
+          filters: *filters
+          requires:
+            - ec2_set-up-run-task-test
+          cluster: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
+          aws-region: AWS_DEFAULT_REGION
+          task-definition: "${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360"
+          launch-type: "EC2"
+          awsvpc: false
+          overrides: '{"containerOverrides":[{"name": "sleep", "memory": 512}]}'
+          context: [CPE_ORBS_AWS]
+      - tear-down-run-task-test:
+          name: ec2_tear-down-run-task-test
+          filters: *filters
+          requires:
+            - ec2_run-task-test
+          family-name: ${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360
+          context: [CPE_ORBS_AWS]
 
-#       - test-service-update:
-#           name: ec2_test-update-service-command
-#           filters: *filters
-#           requires:
-#             - ec2_set-up-test-env
-#           aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
-#           family-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
-#           service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
-#           docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
-#           docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}:${CIRCLE_SHA1}"
-#           context: [CPE_ORBS_AWS]
-#       - test-task-definition-update:
-#           name: ec2_test-task-definition-update
-#           family-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
-#           context: [CPE_ORBS_AWS]
-#           filters: *filters
-#           requires:
-#             - ec2_test-update-service-command
-#       - aws-ecs/deploy-service-update:
-#           name: ec2_test-update-service-job
-#           docker-image-for-job: cimg/python:3.10.4
-#           context: [CPE_ORBS_AWS]
-#           filters: *filters
-#           requires:
-#             - ec2_test-task-definition-update
-#           aws-access-key-id: AWS_ACCESS_KEY_ID
-#           aws-region: AWS_DEFAULT_REGION
-#           family: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
-#           service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
-#           cluster-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
-#           container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_EC2}-service,name=VERSION_INFO,value="Asterisk * expansion test ${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_EC2}-service,name=BUILD_DATE,value=$(date)'
-#           verify-revision-is-deployed: true
-#           fail-on-verification-timeout: false
-#           post-steps:
-#             - test-deployment:
-#                 service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
-#                 cluster-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
-#                 test-asterisk-expansion: true
+      - test-service-update:
+          name: ec2_test-update-service-command
+          filters: *filters
+          requires:
+            - ec2_set-up-test-env
+          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
+          family-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
+          service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
+          docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+          docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}:${CIRCLE_SHA1}"
+          context: [CPE_ORBS_AWS]
+      - test-task-definition-update:
+          name: ec2_test-task-definition-update
+          family-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
+          context: [CPE_ORBS_AWS]
+          filters: *filters
+          requires:
+            - ec2_test-update-service-command
+      - aws-ecs/deploy-service-update:
+          name: ec2_test-update-service-job
+          docker-image-for-job: cimg/python:3.10.4
+          context: [CPE_ORBS_AWS]
+          filters: *filters
+          requires:
+            - ec2_test-task-definition-update
+          aws-access-key-id: AWS_ACCESS_KEY_ID
+          aws-region: AWS_DEFAULT_REGION
+          family: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
+          service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
+          cluster-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
+          container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_EC2}-service,name=VERSION_INFO,value="Asterisk * expansion test ${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_EC2}-service,name=BUILD_DATE,value=$(date)'
+          verify-revision-is-deployed: true
+          fail-on-verification-timeout: false
+          post-steps:
+            - test-deployment:
+                service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
+                cluster-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
+                test-asterisk-expansion: true
 
-#       - tear-down-test-env:
-#           name: ec2_tear-down-test-env
-#           filters: *filters
-#           requires:
-#             - ec2_test-update-service-job
-#             - ec2_tear-down-run-task-test
-#           aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
-#           terraform-config-dir: "tests/terraform_setup/ec2"
-#           context: [CPE_ORBS_AWS]
+      - tear-down-test-env:
+          name: ec2_tear-down-test-env
+          filters: *filters
+          requires:
+            - ec2_test-update-service-job
+            - ec2_tear-down-run-task-test
+          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
+          terraform-config-dir: "tests/terraform_setup/ec2"
+          context: [CPE_ORBS_AWS]
 
-#       # #################
-#       # # FargateSpot
-#       # #################
+      # #################
+      # # FargateSpot
+      # #################
 
-#       - test-fargatespot:
-#           context: [CPE_ORBS_AWS]
-#           filters: *filters
-#           requires:
-#             - fargate_set-up-test-env
+      - test-fargatespot:
+          context: [CPE_ORBS_AWS]
+          filters: *filters
+          requires:
+            - fargate_set-up-test-env
 
-#       #################
-#       # CodeDeploy
-#       #################
-#       - build-test-app:
-#           name: codedeploy_fargate_build-test-app
-#           docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
-#           docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
-#           context: [CPE_ORBS_AWS]
-#           filters: *filters
-#       - set-up-test-env:
-#           name: codedeploy_fargate_set-up-test-env
-#           filters: *filters
-#           requires:
-#             - codedeploy_fargate_build-test-app
-#           terraform-image: "hashicorp/terraform:1.1.9"
-#           aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
-#           terraform-config-dir: "tests/terraform_setup/fargate_codedeploy"
-#           context: [CPE_ORBS_AWS]
-#       - test-service-update:
-#           name: codedeploy_fargate_test-update-service-command
-#           filters: *filters
-#           requires:
-#             - codedeploy_fargate_set-up-test-env
-#           aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
-#           family-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-#           service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-#           docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
-#           docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
-#           skip-service-update: true
-#           context: [CPE_ORBS_AWS]
-#       - aws-ecs/deploy-service-update:
-#           name: codedeploy_fargate_test-update-service-job
-#           docker-image-for-job: cimg/python:3.10.4
-#           filters: *filters
-#           requires:
-#             - codedeploy_fargate_test-update-service-command
-#           aws-access-key-id: AWS_ACCESS_KEY_ID
-#           aws-region: AWS_DEFAULT_REGION
-#           family: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-#           cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
-#           container-image-name-updates: "container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,image-and-tag=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
-#           container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=BUILD_DATE,value=$(date)'
-#           deployment-controller: "CODE_DEPLOY"
-#           codedeploy-application-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeployapp"
-#           codedeploy-deployment-group-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
-#           codedeploy-load-balanced-container-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-#           codedeploy-load-balanced-container-port: 8080
-#           verify-revision-is-deployed: false
-#           context: [CPE_ORBS_AWS]
-#           post-steps:
-#             - wait-for-codedeploy-deployment:
-#                 application-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeployapp"
-#                 deployment-group-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
-#             - test-deployment:
-#                 service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-#                 cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
-#                 delete-load-balancer: false
-#       - aws-ecs/deploy-service-update:
-#           name: codedeploy_fargate_test-update-and-wait-service-job
-#           docker-image-for-job: cimg/python:3.10.4
-#           context: [CPE_ORBS_AWS]
-#           filters: *filters
-#           requires:
-#             - codedeploy_fargate_test-update-service-job
-#           aws-access-key-id: AWS_ACCESS_KEY_ID
-#           aws-region: AWS_DEFAULT_REGION
-#           family: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-#           cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
-#           container-image-name-updates: "container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,image-and-tag=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
-#           container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=BUILD_DATE,value=$(date)'
-#           deployment-controller: "CODE_DEPLOY"
-#           codedeploy-application-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeployapp"
-#           codedeploy-deployment-group-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
-#           codedeploy-load-balanced-container-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-#           codedeploy-load-balanced-container-port: 8080
-#           verify-revision-is-deployed: true
-#           verification-timeout: "12m"
-#           post-steps:
-#             - test-deployment:
-#                 service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-#                 cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
-#                 delete-load-balancer: true
-#             - delete-service:
-#                 service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-#                 cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
-#       - tear-down-test-env:
-#           name: codedeploy_fargate_tear-down-test-env
-#           requires:
-#             - codedeploy_fargate_test-update-and-wait-service-job
-#           terraform-image: "hashicorp/terraform:1.1.9"
-#           aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
-#           terraform-config-dir: "tests/terraform_setup/fargate_codedeploy"
-#           context: [CPE_ORBS_AWS]
-#           filters: *filters
-#       - orb-tools/pack:
-#           filters: *filters
-#       - orb-tools/publish:
-#           orb-name: circleci/aws-ecs
-#           vcs-type: << pipeline.project.type >>
-#           pub-type: production
-#           requires:
-#             - orb-tools/pack
-#             - ec2_tear-down-test-env
-#             - fargate_tear-down-test-env  
-#             - codedeploy_fargate_tear-down-test-env
-#           context: orb-publisher
-#           filters:
-#             branches:
-#               ignore: /.*/
-#             tags:
-#               only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
-# commands:
-#   wait-for-codedeploy-deployment:
-#     description: "Wait for the CodeDeploy deployment to be successful"
-#     parameters:
-#       application-name:
-#         description: "CodeDeploy application name"
-#         type: string
-#       deployment-group-name:
-#         description: "CodeDeploy application name"
-#         type: string
-#     steps:
-#       - run:
-#           name: Wait for CodeDeploy deployment to be successful (for orb testing and is not part of the orb)
-#           command: |
-#             DEPLOYMENT_ID=$(aws deploy list-deployments \
-#               --application-name << parameters.application-name >> \
-#               --deployment-group-name << parameters.deployment-group-name >> \
-#               --query "deployments" \
-#               --max-items 1 \
-#               --output text \
-#               | head -n 1)
-#             aws deploy wait deployment-successful --deployment-id ${DEPLOYMENT_ID}
-#   delete-service:
-#     description: "Forcefully delete an ECS service"
-#     parameters:
-#       service-name:
-#         description: "Name of the ECS service"
-#         type: string
-#       cluster-name:
-#         description: "Name of the cluster"
-#         type: string
-#     steps:
-#       - run:
-#           name: Delete ECS service
-#           command: |
-#             aws ecs delete-service \
-#               --cluster << parameters.cluster-name >> \
-#               --service << parameters.service-name >> \
-#               --force
-#   test-deployment:
-#     description: "Test the deployment"
-#     parameters:
-#       service-name:
-#         description: "Name of the ECS service"
-#         type: string
-#       cluster-name:
-#         description: "Name of the cluster"
-#         type: string
-#       test-asterisk-expansion:
-#         description: "Checks that asterisk expansion is prevented"
-#         type: boolean
-#         default: false
-#       delete-load-balancer:
-#         description: "Whether to delete the load balancer after the test"
-#         type: boolean
-#         default: false
-#     steps:
-#       - run:
-#           name: Test deployment (for orb testing and is not part of the orb)
-#           command: |-
-#             set -x
-#             TARGET_GROUP_ARN=$(aws ecs describe-services --cluster << parameters.cluster-name >> --services << parameters.service-name >> | jq -r '.services[0].loadBalancers[0].targetGroupArn')
-#             ELB_ARN=$(aws elbv2 describe-target-groups --target-group-arns $TARGET_GROUP_ARN | jq -r '.TargetGroups[0].LoadBalancerArns[0]')
-#             ELB_DNS_NAME=$(aws elbv2 describe-load-balancers --load-balancer-arns $ELB_ARN | jq -r '.LoadBalancers[0].DNSName')
-#             echo "ELB DNS NAME: $ELB_DNS_NAME"
-#             echo "Sleeping for one minute while waiting for AWS to come online."
-#             sleep 160s
-#             echo "Done sleeping"
-#             curl --retry 10 http://$ELB_DNS_NAME
-#             run_with_retry() {
-#               MAX_RETRY=6
-#               n=0
-#               until [ $n -ge $MAX_RETRY ]
-#               do
-#                 # retry many times in case it takes a while for the new task definition to take effect
-#                 curl -s --retry 10 http://$ELB_DNS_NAME \
-#                   | grep -E "Hello World\!.*${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}" <<#parameters.test-asterisk-expansion>> | grep "Asterisk \* expansion test"<</parameters.test-asterisk-expansion>> && break
-#                 n=$[$n+1]
-#                 sleep 60s
-#               done
-#               if [ $n -ge $MAX_RETRY ]; then
-#                 echo "Error - Retry limit reached"
-#                 exit 1
-#               fi
-#             }
-#             run_with_retry
-#             if [ "<< parameters.delete-load-balancer >>" == "1" ]; then
-#               aws elbv2 delete-load-balancer --load-balancer-arn $ELB_ARN
-#             fi
+      #################
+      # CodeDeploy
+      #################
+      - build-test-app:
+          name: codedeploy_fargate_build-test-app
+          docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+          docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
+          context: [CPE_ORBS_AWS]
+          filters: *filters
+      - set-up-test-env:
+          name: codedeploy_fargate_set-up-test-env
+          filters: *filters
+          requires:
+            - codedeploy_fargate_build-test-app
+          terraform-image: "hashicorp/terraform:1.1.9"
+          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
+          terraform-config-dir: "tests/terraform_setup/fargate_codedeploy"
+          context: [CPE_ORBS_AWS]
+      - test-service-update:
+          name: codedeploy_fargate_test-update-service-command
+          filters: *filters
+          requires:
+            - codedeploy_fargate_set-up-test-env
+          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
+          family-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+          service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+          docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+          docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
+          skip-service-update: true
+          context: [CPE_ORBS_AWS]
+      - aws-ecs/deploy-service-update:
+          name: codedeploy_fargate_test-update-service-job
+          docker-image-for-job: cimg/python:3.10.4
+          filters: *filters
+          requires:
+            - codedeploy_fargate_test-update-service-command
+          aws-access-key-id: AWS_ACCESS_KEY_ID
+          aws-region: AWS_DEFAULT_REGION
+          family: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+          cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+          container-image-name-updates: "container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,image-and-tag=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
+          container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=BUILD_DATE,value=$(date)'
+          deployment-controller: "CODE_DEPLOY"
+          codedeploy-application-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeployapp"
+          codedeploy-deployment-group-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
+          codedeploy-load-balanced-container-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+          codedeploy-load-balanced-container-port: 8080
+          verify-revision-is-deployed: false
+          context: [CPE_ORBS_AWS]
+          post-steps:
+            - wait-for-codedeploy-deployment:
+                application-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeployapp"
+                deployment-group-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
+            - test-deployment:
+                service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+                cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+                delete-load-balancer: false
+      - aws-ecs/deploy-service-update:
+          name: codedeploy_fargate_test-update-and-wait-service-job
+          docker-image-for-job: cimg/python:3.10.4
+          context: [CPE_ORBS_AWS]
+          filters: *filters
+          requires:
+            - codedeploy_fargate_test-update-service-job
+          aws-access-key-id: AWS_ACCESS_KEY_ID
+          aws-region: AWS_DEFAULT_REGION
+          family: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+          cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+          container-image-name-updates: "container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,image-and-tag=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
+          container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=BUILD_DATE,value=$(date)'
+          deployment-controller: "CODE_DEPLOY"
+          codedeploy-application-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeployapp"
+          codedeploy-deployment-group-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
+          codedeploy-load-balanced-container-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+          codedeploy-load-balanced-container-port: 8080
+          verify-revision-is-deployed: true
+          verification-timeout: "12m"
+          post-steps:
+            - test-deployment:
+                service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+                cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+                delete-load-balancer: true
+            - delete-service:
+                service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+                cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+      - tear-down-test-env:
+          name: codedeploy_fargate_tear-down-test-env
+          requires:
+            - codedeploy_fargate_test-update-and-wait-service-job
+          terraform-image: "hashicorp/terraform:1.1.9"
+          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
+          terraform-config-dir: "tests/terraform_setup/fargate_codedeploy"
+          context: [CPE_ORBS_AWS]
+          filters: *filters
+      - orb-tools/pack:
+          filters: *filters
+      - orb-tools/publish:
+          orb-name: circleci/aws-ecs
+          vcs-type: << pipeline.project.type >>
+          pub-type: production
+          requires:
+            - orb-tools/pack
+            - ec2_tear-down-test-env
+            - fargate_tear-down-test-env  
+            - codedeploy_fargate_tear-down-test-env
+            - integration-test-ecs-cli-install
+          context: orb-publisher
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
+commands:
+  wait-for-codedeploy-deployment:
+    description: "Wait for the CodeDeploy deployment to be successful"
+    parameters:
+      application-name:
+        description: "CodeDeploy application name"
+        type: string
+      deployment-group-name:
+        description: "CodeDeploy application name"
+        type: string
+    steps:
+      - run:
+          name: Wait for CodeDeploy deployment to be successful (for orb testing and is not part of the orb)
+          command: |
+            DEPLOYMENT_ID=$(aws deploy list-deployments \
+              --application-name << parameters.application-name >> \
+              --deployment-group-name << parameters.deployment-group-name >> \
+              --query "deployments" \
+              --max-items 1 \
+              --output text \
+              | head -n 1)
+            aws deploy wait deployment-successful --deployment-id ${DEPLOYMENT_ID}
+  delete-service:
+    description: "Forcefully delete an ECS service"
+    parameters:
+      service-name:
+        description: "Name of the ECS service"
+        type: string
+      cluster-name:
+        description: "Name of the cluster"
+        type: string
+    steps:
+      - run:
+          name: Delete ECS service
+          command: |
+            aws ecs delete-service \
+              --cluster << parameters.cluster-name >> \
+              --service << parameters.service-name >> \
+              --force
+  test-deployment:
+    description: "Test the deployment"
+    parameters:
+      service-name:
+        description: "Name of the ECS service"
+        type: string
+      cluster-name:
+        description: "Name of the cluster"
+        type: string
+      test-asterisk-expansion:
+        description: "Checks that asterisk expansion is prevented"
+        type: boolean
+        default: false
+      delete-load-balancer:
+        description: "Whether to delete the load balancer after the test"
+        type: boolean
+        default: false
+    steps:
+      - run:
+          name: Test deployment (for orb testing and is not part of the orb)
+          command: |-
+            set -x
+            TARGET_GROUP_ARN=$(aws ecs describe-services --cluster << parameters.cluster-name >> --services << parameters.service-name >> | jq -r '.services[0].loadBalancers[0].targetGroupArn')
+            ELB_ARN=$(aws elbv2 describe-target-groups --target-group-arns $TARGET_GROUP_ARN | jq -r '.TargetGroups[0].LoadBalancerArns[0]')
+            ELB_DNS_NAME=$(aws elbv2 describe-load-balancers --load-balancer-arns $ELB_ARN | jq -r '.LoadBalancers[0].DNSName')
+            echo "ELB DNS NAME: $ELB_DNS_NAME"
+            echo "Sleeping for one minute while waiting for AWS to come online."
+            sleep 160s
+            echo "Done sleeping"
+            curl --retry 10 http://$ELB_DNS_NAME
+            run_with_retry() {
+              MAX_RETRY=6
+              n=0
+              until [ $n -ge $MAX_RETRY ]
+              do
+                # retry many times in case it takes a while for the new task definition to take effect
+                curl -s --retry 10 http://$ELB_DNS_NAME \
+                  | grep -E "Hello World\!.*${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}" <<#parameters.test-asterisk-expansion>> | grep "Asterisk \* expansion test"<</parameters.test-asterisk-expansion>> && break
+                n=$[$n+1]
+                sleep 60s
+              done
+              if [ $n -ge $MAX_RETRY ]; then
+                echo "Error - Retry limit reached"
+                exit 1
+              fi
+            }
+            run_with_retry
+            if [ "<< parameters.delete-load-balancer >>" == "1" ]; then
+              aws elbv2 delete-load-balancer --load-balancer-arn $ELB_ARN
+            fi
 executors:
   mac:
     macos:
-      xcode: 13.3.6
+      xcode: 13.3.1
   linux:
     docker:
       - image: cimg/base:current

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -342,398 +342,410 @@ jobs:
         type: string
       install-dir:
         type: string
-        default: "/usr/local/ecs-cli"
+        default: "/usr/local/bin/ecs-cli"
         description: |
           Specify the installation directory
     executor: <<parameters.executor>>
     steps:
-      - install-ecs-cli:
+      - aws-ecs/install-ecs-cli:
           version: <<parameters.version>>
           install-dir: <<parameters.install-dir>>
 workflows:
   test-deploy:
     jobs:
       # Make sure to include "filters: *filters" in every test job you want to run as part of your deployment.
-      - 
+      - integration-test-ecs-cli-install:
+          version: "v1.2.1"
+          matrix:
+            parameters:
+              executor: [linux, mac]
+          filters: *filters
       #################
       # Fargate
       #################
-      - build-test-app:
-          name: fargate_build-test-app
-          docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
-          docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}:${CIRCLE_SHA1}"
-          context: [CPE_ORBS_AWS]
-          filters: *filters
-      - set-up-test-env:
-          name: fargate_set-up-test-env
-          filters: *filters
-          requires:
-            - fargate_build-test-app
-          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
-          terraform-config-dir: "tests/terraform_setup/fargate"
-          context: [CPE_ORBS_AWS]
-      - test-service-update:
-          name: fargate_test-update-service-command
-          filters: *filters
-          requires:
-            - fargate_set-up-test-env
-          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
-          family-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
-          service-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
-          docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
-          docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}:${CIRCLE_SHA1}"
-          context: [CPE_ORBS_AWS]
-      - aws-ecs/deploy-service-update:
-          name: fargate_test-update-service-job
-          docker-image-for-job: cimg/python:3.10.4
-          filters: *filters
-          requires:
-            - fargate_test-update-service-command
-          aws-access-key-id: AWS_ACCESS_KEY_ID
-          aws-region: AWS_DEFAULT_REGION
-          profile-name: "ECS_TEST_PROFILE"
-          family: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
-          cluster-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
-          container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service,name=BUILD_DATE,value=$(date)'
-          # test the force-new-deployment flag
-          force-new-deployment: true
-          verify-revision-is-deployed: true
-          max-poll-attempts: 40
-          poll-interval: 10
-          context: [CPE_ORBS_AWS]
-          post-steps:
-            - test-deployment:
-                service-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
-                cluster-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
-      - aws-ecs/deploy-service-update:
-          name: fargate_test-update-service-skip-registration
-          docker-image-for-job: cimg/python:3.10.4
-          filters: *filters
-          requires:
-            - fargate_test-update-service-job
-          aws-access-key-id: AWS_ACCESS_KEY_ID
-          aws-region: AWS_DEFAULT_REGION
-          profile-name: "ECS_TEST_PROFILE"
-          family: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
-          cluster-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
-          # test skipping registration of a new task definition
-          skip-task-definition-registration: true
-          # test the enable-circuit-breaker flag
-          enable-circuit-breaker: true
-          verify-revision-is-deployed: true
-          max-poll-attempts: 40
-          poll-interval: 10
-          context: [CPE_ORBS_AWS]
-      - tear-down-test-env:
-          name: fargate_tear-down-test-env
-          filters: *filters
-          requires:
-            - fargate_test-update-service-skip-registration
-            - test-fargatespot
-          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
-          terraform-config-dir: "tests/terraform_setup/fargate"
-          context: [CPE_ORBS_AWS]
+#       - build-test-app:
+#           name: fargate_build-test-app
+#           docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+#           docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}:${CIRCLE_SHA1}"
+#           context: [CPE_ORBS_AWS]
+#           filters: *filters
+#       - set-up-test-env:
+#           name: fargate_set-up-test-env
+#           filters: *filters
+#           requires:
+#             - fargate_build-test-app
+#           aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
+#           terraform-config-dir: "tests/terraform_setup/fargate"
+#           context: [CPE_ORBS_AWS]
+#       - test-service-update:
+#           name: fargate_test-update-service-command
+#           filters: *filters
+#           requires:
+#             - fargate_set-up-test-env
+#           aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
+#           family-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
+#           service-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
+#           docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+#           docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}:${CIRCLE_SHA1}"
+#           context: [CPE_ORBS_AWS]
+#       - aws-ecs/deploy-service-update:
+#           name: fargate_test-update-service-job
+#           docker-image-for-job: cimg/python:3.10.4
+#           filters: *filters
+#           requires:
+#             - fargate_test-update-service-command
+#           aws-access-key-id: AWS_ACCESS_KEY_ID
+#           aws-region: AWS_DEFAULT_REGION
+#           profile-name: "ECS_TEST_PROFILE"
+#           family: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
+#           cluster-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
+#           container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service,name=BUILD_DATE,value=$(date)'
+#           # test the force-new-deployment flag
+#           force-new-deployment: true
+#           verify-revision-is-deployed: true
+#           max-poll-attempts: 40
+#           poll-interval: 10
+#           context: [CPE_ORBS_AWS]
+#           post-steps:
+#             - test-deployment:
+#                 service-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
+#                 cluster-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
+#       - aws-ecs/deploy-service-update:
+#           name: fargate_test-update-service-skip-registration
+#           docker-image-for-job: cimg/python:3.10.4
+#           filters: *filters
+#           requires:
+#             - fargate_test-update-service-job
+#           aws-access-key-id: AWS_ACCESS_KEY_ID
+#           aws-region: AWS_DEFAULT_REGION
+#           profile-name: "ECS_TEST_PROFILE"
+#           family: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
+#           cluster-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
+#           # test skipping registration of a new task definition
+#           skip-task-definition-registration: true
+#           # test the enable-circuit-breaker flag
+#           enable-circuit-breaker: true
+#           verify-revision-is-deployed: true
+#           max-poll-attempts: 40
+#           poll-interval: 10
+#           context: [CPE_ORBS_AWS]
+#       - tear-down-test-env:
+#           name: fargate_tear-down-test-env
+#           filters: *filters
+#           requires:
+#             - fargate_test-update-service-skip-registration
+#             - test-fargatespot
+#           aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
+#           terraform-config-dir: "tests/terraform_setup/fargate"
+#           context: [CPE_ORBS_AWS]
 
-      #################
-      # EC2
-      #################
-      - build-test-app:
-          name: ec2_build-test-app
-          docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
-          docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}:${CIRCLE_SHA1}"
-          context: [CPE_ORBS_AWS]
-          filters: *filters
-      - set-up-test-env:
-          name: ec2_set-up-test-env
-          filters: *filters
-          requires:
-            - ec2_build-test-app
-          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
-          terraform-config-dir: "tests/terraform_setup/ec2"
-          context: [CPE_ORBS_AWS]
-      - set-up-run-task-test:
-          name: ec2_set-up-run-task-test
-          filters: *filters
-          requires:
-            - ec2_set-up-test-env
-          family-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360"
-          context: [CPE_ORBS_AWS]
-      - aws-ecs/run-task:
-          name: ec2_run-task-test
-          filters: *filters
-          requires:
-            - ec2_set-up-run-task-test
-          cluster: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
-          aws-region: AWS_DEFAULT_REGION
-          task-definition: "${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360"
-          launch-type: "EC2"
-          awsvpc: false
-          overrides: '{"containerOverrides":[{"name": "sleep", "memory": 512}]}'
-          context: [CPE_ORBS_AWS]
-      - tear-down-run-task-test:
-          name: ec2_tear-down-run-task-test
-          filters: *filters
-          requires:
-            - ec2_run-task-test
-          family-name: ${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360
-          context: [CPE_ORBS_AWS]
+#       #################
+#       # EC2
+#       #################
+#       - build-test-app:
+#           name: ec2_build-test-app
+#           docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+#           docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}:${CIRCLE_SHA1}"
+#           context: [CPE_ORBS_AWS]
+#           filters: *filters
+#       - set-up-test-env:
+#           name: ec2_set-up-test-env
+#           filters: *filters
+#           requires:
+#             - ec2_build-test-app
+#           aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
+#           terraform-config-dir: "tests/terraform_setup/ec2"
+#           context: [CPE_ORBS_AWS]
+#       - set-up-run-task-test:
+#           name: ec2_set-up-run-task-test
+#           filters: *filters
+#           requires:
+#             - ec2_set-up-test-env
+#           family-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360"
+#           context: [CPE_ORBS_AWS]
+#       - aws-ecs/run-task:
+#           name: ec2_run-task-test
+#           filters: *filters
+#           requires:
+#             - ec2_set-up-run-task-test
+#           cluster: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
+#           aws-region: AWS_DEFAULT_REGION
+#           task-definition: "${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360"
+#           launch-type: "EC2"
+#           awsvpc: false
+#           overrides: '{"containerOverrides":[{"name": "sleep", "memory": 512}]}'
+#           context: [CPE_ORBS_AWS]
+#       - tear-down-run-task-test:
+#           name: ec2_tear-down-run-task-test
+#           filters: *filters
+#           requires:
+#             - ec2_run-task-test
+#           family-name: ${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360
+#           context: [CPE_ORBS_AWS]
 
-      - test-service-update:
-          name: ec2_test-update-service-command
-          filters: *filters
-          requires:
-            - ec2_set-up-test-env
-          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
-          family-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
-          service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
-          docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
-          docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}:${CIRCLE_SHA1}"
-          context: [CPE_ORBS_AWS]
-      - test-task-definition-update:
-          name: ec2_test-task-definition-update
-          family-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
-          context: [CPE_ORBS_AWS]
-          filters: *filters
-          requires:
-            - ec2_test-update-service-command
-      - aws-ecs/deploy-service-update:
-          name: ec2_test-update-service-job
-          docker-image-for-job: cimg/python:3.10.4
-          context: [CPE_ORBS_AWS]
-          filters: *filters
-          requires:
-            - ec2_test-task-definition-update
-          aws-access-key-id: AWS_ACCESS_KEY_ID
-          aws-region: AWS_DEFAULT_REGION
-          family: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
-          service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
-          cluster-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
-          container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_EC2}-service,name=VERSION_INFO,value="Asterisk * expansion test ${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_EC2}-service,name=BUILD_DATE,value=$(date)'
-          verify-revision-is-deployed: true
-          fail-on-verification-timeout: false
-          post-steps:
-            - test-deployment:
-                service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
-                cluster-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
-                test-asterisk-expansion: true
+#       - test-service-update:
+#           name: ec2_test-update-service-command
+#           filters: *filters
+#           requires:
+#             - ec2_set-up-test-env
+#           aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
+#           family-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
+#           service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
+#           docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+#           docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}:${CIRCLE_SHA1}"
+#           context: [CPE_ORBS_AWS]
+#       - test-task-definition-update:
+#           name: ec2_test-task-definition-update
+#           family-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
+#           context: [CPE_ORBS_AWS]
+#           filters: *filters
+#           requires:
+#             - ec2_test-update-service-command
+#       - aws-ecs/deploy-service-update:
+#           name: ec2_test-update-service-job
+#           docker-image-for-job: cimg/python:3.10.4
+#           context: [CPE_ORBS_AWS]
+#           filters: *filters
+#           requires:
+#             - ec2_test-task-definition-update
+#           aws-access-key-id: AWS_ACCESS_KEY_ID
+#           aws-region: AWS_DEFAULT_REGION
+#           family: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
+#           service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
+#           cluster-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
+#           container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_EC2}-service,name=VERSION_INFO,value="Asterisk * expansion test ${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_EC2}-service,name=BUILD_DATE,value=$(date)'
+#           verify-revision-is-deployed: true
+#           fail-on-verification-timeout: false
+#           post-steps:
+#             - test-deployment:
+#                 service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
+#                 cluster-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
+#                 test-asterisk-expansion: true
 
-      - tear-down-test-env:
-          name: ec2_tear-down-test-env
-          filters: *filters
-          requires:
-            - ec2_test-update-service-job
-            - ec2_tear-down-run-task-test
-          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
-          terraform-config-dir: "tests/terraform_setup/ec2"
-          context: [CPE_ORBS_AWS]
+#       - tear-down-test-env:
+#           name: ec2_tear-down-test-env
+#           filters: *filters
+#           requires:
+#             - ec2_test-update-service-job
+#             - ec2_tear-down-run-task-test
+#           aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
+#           terraform-config-dir: "tests/terraform_setup/ec2"
+#           context: [CPE_ORBS_AWS]
 
-      # #################
-      # # FargateSpot
-      # #################
+#       # #################
+#       # # FargateSpot
+#       # #################
 
-      - test-fargatespot:
-          context: [CPE_ORBS_AWS]
-          filters: *filters
-          requires:
-            - fargate_set-up-test-env
+#       - test-fargatespot:
+#           context: [CPE_ORBS_AWS]
+#           filters: *filters
+#           requires:
+#             - fargate_set-up-test-env
 
-      #################
-      # CodeDeploy
-      #################
-      - build-test-app:
-          name: codedeploy_fargate_build-test-app
-          docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
-          docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
-          context: [CPE_ORBS_AWS]
-          filters: *filters
-      - set-up-test-env:
-          name: codedeploy_fargate_set-up-test-env
-          filters: *filters
-          requires:
-            - codedeploy_fargate_build-test-app
-          terraform-image: "hashicorp/terraform:1.1.9"
-          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
-          terraform-config-dir: "tests/terraform_setup/fargate_codedeploy"
-          context: [CPE_ORBS_AWS]
-      - test-service-update:
-          name: codedeploy_fargate_test-update-service-command
-          filters: *filters
-          requires:
-            - codedeploy_fargate_set-up-test-env
-          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
-          family-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-          service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-          docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
-          docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
-          skip-service-update: true
-          context: [CPE_ORBS_AWS]
-      - aws-ecs/deploy-service-update:
-          name: codedeploy_fargate_test-update-service-job
-          docker-image-for-job: cimg/python:3.10.4
-          filters: *filters
-          requires:
-            - codedeploy_fargate_test-update-service-command
-          aws-access-key-id: AWS_ACCESS_KEY_ID
-          aws-region: AWS_DEFAULT_REGION
-          family: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-          cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
-          container-image-name-updates: "container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,image-and-tag=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
-          container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=BUILD_DATE,value=$(date)'
-          deployment-controller: "CODE_DEPLOY"
-          codedeploy-application-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeployapp"
-          codedeploy-deployment-group-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
-          codedeploy-load-balanced-container-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-          codedeploy-load-balanced-container-port: 8080
-          verify-revision-is-deployed: false
-          context: [CPE_ORBS_AWS]
-          post-steps:
-            - wait-for-codedeploy-deployment:
-                application-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeployapp"
-                deployment-group-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
-            - test-deployment:
-                service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-                cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
-                delete-load-balancer: false
-      - aws-ecs/deploy-service-update:
-          name: codedeploy_fargate_test-update-and-wait-service-job
-          docker-image-for-job: cimg/python:3.10.4
-          context: [CPE_ORBS_AWS]
-          filters: *filters
-          requires:
-            - codedeploy_fargate_test-update-service-job
-          aws-access-key-id: AWS_ACCESS_KEY_ID
-          aws-region: AWS_DEFAULT_REGION
-          family: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-          cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
-          container-image-name-updates: "container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,image-and-tag=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
-          container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=BUILD_DATE,value=$(date)'
-          deployment-controller: "CODE_DEPLOY"
-          codedeploy-application-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeployapp"
-          codedeploy-deployment-group-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
-          codedeploy-load-balanced-container-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-          codedeploy-load-balanced-container-port: 8080
-          verify-revision-is-deployed: true
-          verification-timeout: "12m"
-          post-steps:
-            - test-deployment:
-                service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-                cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
-                delete-load-balancer: true
-            - delete-service:
-                service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-                cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
-      - tear-down-test-env:
-          name: codedeploy_fargate_tear-down-test-env
-          requires:
-            - codedeploy_fargate_test-update-and-wait-service-job
-          terraform-image: "hashicorp/terraform:1.1.9"
-          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
-          terraform-config-dir: "tests/terraform_setup/fargate_codedeploy"
-          context: [CPE_ORBS_AWS]
-          filters: *filters
-      - orb-tools/pack:
-          filters: *filters
-      - orb-tools/publish:
-          orb-name: circleci/aws-ecs
-          vcs-type: << pipeline.project.type >>
-          pub-type: production
-          requires:
-            - orb-tools/pack
-            - ec2_tear-down-test-env
-            - fargate_tear-down-test-env  
-            - codedeploy_fargate_tear-down-test-env
-          context: orb-publisher
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
-commands:
-  wait-for-codedeploy-deployment:
-    description: "Wait for the CodeDeploy deployment to be successful"
-    parameters:
-      application-name:
-        description: "CodeDeploy application name"
-        type: string
-      deployment-group-name:
-        description: "CodeDeploy application name"
-        type: string
-    steps:
-      - run:
-          name: Wait for CodeDeploy deployment to be successful (for orb testing and is not part of the orb)
-          command: |
-            DEPLOYMENT_ID=$(aws deploy list-deployments \
-              --application-name << parameters.application-name >> \
-              --deployment-group-name << parameters.deployment-group-name >> \
-              --query "deployments" \
-              --max-items 1 \
-              --output text \
-              | head -n 1)
-            aws deploy wait deployment-successful --deployment-id ${DEPLOYMENT_ID}
-  delete-service:
-    description: "Forcefully delete an ECS service"
-    parameters:
-      service-name:
-        description: "Name of the ECS service"
-        type: string
-      cluster-name:
-        description: "Name of the cluster"
-        type: string
-    steps:
-      - run:
-          name: Delete ECS service
-          command: |
-            aws ecs delete-service \
-              --cluster << parameters.cluster-name >> \
-              --service << parameters.service-name >> \
-              --force
-  test-deployment:
-    description: "Test the deployment"
-    parameters:
-      service-name:
-        description: "Name of the ECS service"
-        type: string
-      cluster-name:
-        description: "Name of the cluster"
-        type: string
-      test-asterisk-expansion:
-        description: "Checks that asterisk expansion is prevented"
-        type: boolean
-        default: false
-      delete-load-balancer:
-        description: "Whether to delete the load balancer after the test"
-        type: boolean
-        default: false
-    steps:
-      - run:
-          name: Test deployment (for orb testing and is not part of the orb)
-          command: |-
-            set -x
-            TARGET_GROUP_ARN=$(aws ecs describe-services --cluster << parameters.cluster-name >> --services << parameters.service-name >> | jq -r '.services[0].loadBalancers[0].targetGroupArn')
-            ELB_ARN=$(aws elbv2 describe-target-groups --target-group-arns $TARGET_GROUP_ARN | jq -r '.TargetGroups[0].LoadBalancerArns[0]')
-            ELB_DNS_NAME=$(aws elbv2 describe-load-balancers --load-balancer-arns $ELB_ARN | jq -r '.LoadBalancers[0].DNSName')
-            echo "ELB DNS NAME: $ELB_DNS_NAME"
-            echo "Sleeping for one minute while waiting for AWS to come online."
-            sleep 160s
-            echo "Done sleeping"
-            curl --retry 10 http://$ELB_DNS_NAME
-            run_with_retry() {
-              MAX_RETRY=6
-              n=0
-              until [ $n -ge $MAX_RETRY ]
-              do
-                # retry many times in case it takes a while for the new task definition to take effect
-                curl -s --retry 10 http://$ELB_DNS_NAME \
-                  | grep -E "Hello World\!.*${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}" <<#parameters.test-asterisk-expansion>> | grep "Asterisk \* expansion test"<</parameters.test-asterisk-expansion>> && break
-                n=$[$n+1]
-                sleep 60s
-              done
-              if [ $n -ge $MAX_RETRY ]; then
-                echo "Error - Retry limit reached"
-                exit 1
-              fi
-            }
-            run_with_retry
-            if [ "<< parameters.delete-load-balancer >>" == "1" ]; then
-              aws elbv2 delete-load-balancer --load-balancer-arn $ELB_ARN
-            fi
+#       #################
+#       # CodeDeploy
+#       #################
+#       - build-test-app:
+#           name: codedeploy_fargate_build-test-app
+#           docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+#           docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
+#           context: [CPE_ORBS_AWS]
+#           filters: *filters
+#       - set-up-test-env:
+#           name: codedeploy_fargate_set-up-test-env
+#           filters: *filters
+#           requires:
+#             - codedeploy_fargate_build-test-app
+#           terraform-image: "hashicorp/terraform:1.1.9"
+#           aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
+#           terraform-config-dir: "tests/terraform_setup/fargate_codedeploy"
+#           context: [CPE_ORBS_AWS]
+#       - test-service-update:
+#           name: codedeploy_fargate_test-update-service-command
+#           filters: *filters
+#           requires:
+#             - codedeploy_fargate_set-up-test-env
+#           aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
+#           family-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+#           service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+#           docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+#           docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
+#           skip-service-update: true
+#           context: [CPE_ORBS_AWS]
+#       - aws-ecs/deploy-service-update:
+#           name: codedeploy_fargate_test-update-service-job
+#           docker-image-for-job: cimg/python:3.10.4
+#           filters: *filters
+#           requires:
+#             - codedeploy_fargate_test-update-service-command
+#           aws-access-key-id: AWS_ACCESS_KEY_ID
+#           aws-region: AWS_DEFAULT_REGION
+#           family: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+#           cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+#           container-image-name-updates: "container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,image-and-tag=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
+#           container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=BUILD_DATE,value=$(date)'
+#           deployment-controller: "CODE_DEPLOY"
+#           codedeploy-application-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeployapp"
+#           codedeploy-deployment-group-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
+#           codedeploy-load-balanced-container-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+#           codedeploy-load-balanced-container-port: 8080
+#           verify-revision-is-deployed: false
+#           context: [CPE_ORBS_AWS]
+#           post-steps:
+#             - wait-for-codedeploy-deployment:
+#                 application-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeployapp"
+#                 deployment-group-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
+#             - test-deployment:
+#                 service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+#                 cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+#                 delete-load-balancer: false
+#       - aws-ecs/deploy-service-update:
+#           name: codedeploy_fargate_test-update-and-wait-service-job
+#           docker-image-for-job: cimg/python:3.10.4
+#           context: [CPE_ORBS_AWS]
+#           filters: *filters
+#           requires:
+#             - codedeploy_fargate_test-update-service-job
+#           aws-access-key-id: AWS_ACCESS_KEY_ID
+#           aws-region: AWS_DEFAULT_REGION
+#           family: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+#           cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+#           container-image-name-updates: "container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,image-and-tag=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
+#           container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=BUILD_DATE,value=$(date)'
+#           deployment-controller: "CODE_DEPLOY"
+#           codedeploy-application-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeployapp"
+#           codedeploy-deployment-group-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
+#           codedeploy-load-balanced-container-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+#           codedeploy-load-balanced-container-port: 8080
+#           verify-revision-is-deployed: true
+#           verification-timeout: "12m"
+#           post-steps:
+#             - test-deployment:
+#                 service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+#                 cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+#                 delete-load-balancer: true
+#             - delete-service:
+#                 service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+#                 cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+#       - tear-down-test-env:
+#           name: codedeploy_fargate_tear-down-test-env
+#           requires:
+#             - codedeploy_fargate_test-update-and-wait-service-job
+#           terraform-image: "hashicorp/terraform:1.1.9"
+#           aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
+#           terraform-config-dir: "tests/terraform_setup/fargate_codedeploy"
+#           context: [CPE_ORBS_AWS]
+#           filters: *filters
+#       - orb-tools/pack:
+#           filters: *filters
+#       - orb-tools/publish:
+#           orb-name: circleci/aws-ecs
+#           vcs-type: << pipeline.project.type >>
+#           pub-type: production
+#           requires:
+#             - orb-tools/pack
+#             - ec2_tear-down-test-env
+#             - fargate_tear-down-test-env  
+#             - codedeploy_fargate_tear-down-test-env
+#           context: orb-publisher
+#           filters:
+#             branches:
+#               ignore: /.*/
+#             tags:
+#               only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
+# commands:
+#   wait-for-codedeploy-deployment:
+#     description: "Wait for the CodeDeploy deployment to be successful"
+#     parameters:
+#       application-name:
+#         description: "CodeDeploy application name"
+#         type: string
+#       deployment-group-name:
+#         description: "CodeDeploy application name"
+#         type: string
+#     steps:
+#       - run:
+#           name: Wait for CodeDeploy deployment to be successful (for orb testing and is not part of the orb)
+#           command: |
+#             DEPLOYMENT_ID=$(aws deploy list-deployments \
+#               --application-name << parameters.application-name >> \
+#               --deployment-group-name << parameters.deployment-group-name >> \
+#               --query "deployments" \
+#               --max-items 1 \
+#               --output text \
+#               | head -n 1)
+#             aws deploy wait deployment-successful --deployment-id ${DEPLOYMENT_ID}
+#   delete-service:
+#     description: "Forcefully delete an ECS service"
+#     parameters:
+#       service-name:
+#         description: "Name of the ECS service"
+#         type: string
+#       cluster-name:
+#         description: "Name of the cluster"
+#         type: string
+#     steps:
+#       - run:
+#           name: Delete ECS service
+#           command: |
+#             aws ecs delete-service \
+#               --cluster << parameters.cluster-name >> \
+#               --service << parameters.service-name >> \
+#               --force
+#   test-deployment:
+#     description: "Test the deployment"
+#     parameters:
+#       service-name:
+#         description: "Name of the ECS service"
+#         type: string
+#       cluster-name:
+#         description: "Name of the cluster"
+#         type: string
+#       test-asterisk-expansion:
+#         description: "Checks that asterisk expansion is prevented"
+#         type: boolean
+#         default: false
+#       delete-load-balancer:
+#         description: "Whether to delete the load balancer after the test"
+#         type: boolean
+#         default: false
+#     steps:
+#       - run:
+#           name: Test deployment (for orb testing and is not part of the orb)
+#           command: |-
+#             set -x
+#             TARGET_GROUP_ARN=$(aws ecs describe-services --cluster << parameters.cluster-name >> --services << parameters.service-name >> | jq -r '.services[0].loadBalancers[0].targetGroupArn')
+#             ELB_ARN=$(aws elbv2 describe-target-groups --target-group-arns $TARGET_GROUP_ARN | jq -r '.TargetGroups[0].LoadBalancerArns[0]')
+#             ELB_DNS_NAME=$(aws elbv2 describe-load-balancers --load-balancer-arns $ELB_ARN | jq -r '.LoadBalancers[0].DNSName')
+#             echo "ELB DNS NAME: $ELB_DNS_NAME"
+#             echo "Sleeping for one minute while waiting for AWS to come online."
+#             sleep 160s
+#             echo "Done sleeping"
+#             curl --retry 10 http://$ELB_DNS_NAME
+#             run_with_retry() {
+#               MAX_RETRY=6
+#               n=0
+#               until [ $n -ge $MAX_RETRY ]
+#               do
+#                 # retry many times in case it takes a while for the new task definition to take effect
+#                 curl -s --retry 10 http://$ELB_DNS_NAME \
+#                   | grep -E "Hello World\!.*${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}" <<#parameters.test-asterisk-expansion>> | grep "Asterisk \* expansion test"<</parameters.test-asterisk-expansion>> && break
+#                 n=$[$n+1]
+#                 sleep 60s
+#               done
+#               if [ $n -ge $MAX_RETRY ]; then
+#                 echo "Error - Retry limit reached"
+#                 exit 1
+#               fi
+#             }
+#             run_with_retry
+#             if [ "<< parameters.delete-load-balancer >>" == "1" ]; then
+#               aws elbv2 delete-load-balancer --load-balancer-arn $ELB_ARN
+#             fi
+executors:
+  mac:
+    macos:
+      xcode: 13.3.6
+  linux:
+    docker:
+      - image: cimg/base:current

--- a/src/commands/install-ecs-cli.yml
+++ b/src/commands/install-ecs-cli.yml
@@ -9,6 +9,12 @@ parameters:
     description: Specify the installation directory for the AWS ECS CLI. By default, the installation directory will be /usr/local/bin/ecs-cli.
     type: string
     default: /usr/local/bin/ecs-cli
+  override-installed:
+    type: boolean
+    default: false
+    description: |
+      By default, if the AWS ECS CLI is detected on the system, the install will be skipped.
+      Enable this to override the installed version and install your specified version.
 
 steps:
   - run:
@@ -16,4 +22,5 @@ steps:
       environment:
         ECS_PARAM_VERSION: <<parameters.version>>
         ECS_PARAM_INSTALL_DIR: <<parameters.install-dir>>
+        ECS_PARAM_OVERRIDE_INSTALLED: <<parameters.override-installed>>
       command: <<include(scripts/install-ecs-cli.sh)>>

--- a/src/commands/install-ecs-cli.yml
+++ b/src/commands/install-ecs-cli.yml
@@ -1,0 +1,19 @@
+description: "Installs the AWS ECS CLI"
+
+parameters:
+  version:
+    description: Specify the  version of the AWS ECS CLI to install. By default, the latest version will be installed.
+    type: string
+    default: latest
+  install-dir:
+    description: Specify the installation directory for the AWS ECS CLI. By default, the installation directory will be /usr/local/bin/ecs-cli.
+    type: string
+    default: /usr/local/bin/ecs-cli
+
+steps:
+  - run:
+      name: Install AWS ECS CLI
+      environment:
+        ECS_PARAM_VERSION: <<parameters.version>>
+        ECS_PARAM_INSTALL_DIR: <<parameters.install-dir>>
+      command: <<include(scripts/install-ecs-cli.sh)>>

--- a/src/scripts/install-ecs-cli.sh
+++ b/src/scripts/install-ecs-cli.sh
@@ -1,0 +1,19 @@
+if [ $EUID == 0 ]; then export SUDO=""; else export SUDO="sudo"; fi
+
+# Platform check
+if uname -a | grep "Darwin"; then
+    export SYS_ENV_PLATFORM="darwin"
+elif uname -a | grep "Linux"; then
+    export SYS_ENV_PLATFORM="linux"
+else
+    echo "This platform appears to be unsupported."
+    uname -a
+    exit 1
+fi
+
+
+$SUDO curl -Lo "${ECS_PARAM_INSTALL_DIR}" "https://amazon-ecs-cli.s3.amazonaws.com/ecs-cli-${SYS_ENV_PLATFORM}-amd64-${ECS_PARAM_VERSION}"
+
+$SUDO chmod +x "${ECS_PARAM_INSTALL_DIR}"
+
+ecs-cli --version

--- a/src/scripts/install-ecs-cli.sh
+++ b/src/scripts/install-ecs-cli.sh
@@ -11,6 +11,8 @@ else
     exit 1
 fi
 
+echo "https://amazon-ecs-cli.s3.amazonaws.com/ecs-cli-${SYS_ENV_PLATFORM}-amd64-${ECS_PARAM_VERSION}" >> test.txt
+echo "${ECS_PARAM_INSTALL_DIR}" >> test.txt
 
 $SUDO curl -Lo "${ECS_PARAM_INSTALL_DIR}" "https://amazon-ecs-cli.s3.amazonaws.com/ecs-cli-${SYS_ENV_PLATFORM}-amd64-${ECS_PARAM_VERSION}"
 

--- a/src/scripts/install-ecs-cli.sh
+++ b/src/scripts/install-ecs-cli.sh
@@ -3,7 +3,15 @@ if [ $EUID == 0 ]; then export SUDO=""; else export SUDO="sudo"; fi
 # Platform check
 if uname -a | grep "Darwin"; then
     export SYS_ENV_PLATFORM="darwin"
-elif uname -a | grep "Linux"; then
+    MACOS_VERSION=$(sw_vers -productVersion | cut -d. -f1)
+    DELIMIT_VERSION=$(echo "$ECS_PARAM_VERSION" | cut -dv -f2)
+    MAJOR=$(echo "$DELIMIT_VERSION" | cut -d. -f1)
+    MINOR=$(echo "$DELIMIT_VERSION" | cut -d. -f2)
+    if [ "$MACOS_VERSION" -ge "12" ] && [ "$MAJOR" -le "1" ] && [ "$MINOR" -lt "9" ]; then
+        echo "Error: ECS CLI version ${ECS_PARAM_VERSION} is not supported with macOS version ${MACOS_VERSION}. Please upgrade to macOS version 1.9 or later."
+        exit 1
+    fi
+elif uname -a | grep "x86_64 GNU/Linux"; then
     export SYS_ENV_PLATFORM="linux"
 else
     echo "This platform appears to be unsupported."
@@ -11,11 +19,30 @@ else
     exit 1
 fi
 
-echo "https://amazon-ecs-cli.s3.amazonaws.com/ecs-cli-${SYS_ENV_PLATFORM}-amd64-${ECS_PARAM_VERSION}" >> test.txt
-echo "${ECS_PARAM_INSTALL_DIR}" >> test.txt
+Install_ECS_CLI(){
+    $SUDO curl -Lo "${ECS_PARAM_INSTALL_DIR}" "https://amazon-ecs-cli.s3.amazonaws.com/ecs-cli-${SYS_ENV_PLATFORM}-amd64-$1"
+    $SUDO chmod +x "${ECS_PARAM_INSTALL_DIR}"
+}
 
-$SUDO curl -Lo "${ECS_PARAM_INSTALL_DIR}" "https://amazon-ecs-cli.s3.amazonaws.com/ecs-cli-${SYS_ENV_PLATFORM}-amd64-${ECS_PARAM_VERSION}"
+Uninstall_ECS_CLI(){
+    echo "Uninstalling ECS CLI..."
+    ECS_CLI_PATH="$(command -v ecs-cli)"
+    $SUDO rm -rf "${ECS_CLI_PATH}"
+}
 
-$SUDO chmod +x "${ECS_PARAM_INSTALL_DIR}"
+if ! command -v ecs-cli; then
+    echo "Installing ECS CLI..."
+    Install_ECS_CLI "${ECS_PARAM_VERSION}"
+    ecs-cli --version
+else
+    if [ "$ECS_PARAM_OVERRIDE_INSTALLED" = 1 ]; then
+        echo "Overriding installed ECS CLI..."
+        Uninstall_ECS_CLI
+        Install_ECS_CLI "${ECS_PARAM_VERSION}"
+        ecs-cli --version
+    else
+        echo "ECS CLI is already installed."
+        ecs-cli --version
+    fi
+fi
 
-ecs-cli --version

--- a/src/scripts/register-new-task-def.sh
+++ b/src/scripts/register-new-task-def.sh
@@ -25,7 +25,7 @@ if [ -n "${CCI_ORB_AWS_ECS_PLACEMENT_CONSTRAINTS}" ] && [ "${CCI_ORB_AWS_ECS_PLA
 fi
 
 if [ -n "${CCI_ORB_AWS_ECS_REQ_COMP}" ] && [ "${CCI_ORB_AWS_ECS_REQ_COMP}" != "[]" ]; then
-    set -- "$@" --requires-compatibilities ${CCI_ORB_AWS_ECS_REQ_COMP}
+    set -- "$@" --requires-compatibilities "${CCI_ORB_AWS_ECS_REQ_COMP}"
 fi
 
 if [ -n "${CCI_ORB_AWS_ECS_TASK_CPU}" ]; then

--- a/src/scripts/register-new-task-def.sh
+++ b/src/scripts/register-new-task-def.sh
@@ -25,7 +25,8 @@ if [ -n "${CCI_ORB_AWS_ECS_PLACEMENT_CONSTRAINTS}" ] && [ "${CCI_ORB_AWS_ECS_PLA
 fi
 
 if [ -n "${CCI_ORB_AWS_ECS_REQ_COMP}" ] && [ "${CCI_ORB_AWS_ECS_REQ_COMP}" != "[]" ]; then
-    set -- "$@" --requires-compatibilities "${CCI_ORB_AWS_ECS_REQ_COMP}"
+    #shellcheck disable=SC2086
+    set -- "$@" --requires-compatibilities ${CCI_ORB_AWS_ECS_REQ_COMP}
 fi
 
 if [ -n "${CCI_ORB_AWS_ECS_TASK_CPU}" ]; then

--- a/src/scripts/verify-revision-is-deployed.sh
+++ b/src/scripts/verify-revision-is-deployed.sh
@@ -60,3 +60,4 @@ echo "Stopped waiting for deployment to be stable - please check the status of $
 if [ "$ECS_PARAM_FAIL_ON_VERIFY_TIMEOUT" = "1" ]; then
     exit 1
 fi
+


### PR DESCRIPTION
This PR adds the `install-ecs-cli` command which lets users install the `AWS ECS CLI`. Users are able to create, update and monitor clusters and tasks directly from the command line. 