### PR TITLE
fix: addressed override parameter interpolation 

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -359,12 +359,12 @@ workflows:
   test-deploy:
     jobs:
       # Make sure to include "filters: *filters" in every test job you want to run as part of your deployment.
-      # - integration-test-ecs-cli-install:
-      #     version: "v1.9.0"
-      #     matrix:
-      #       parameters:
-      #         executor: [linux, mac]
-      #     filters: *filters
+      - integration-test-ecs-cli-install:
+          version: "v1.9.0"
+          matrix:
+            parameters:
+              executor: [linux, mac]
+          filters: *filters
       #################
       # Fargate
       #################
@@ -447,95 +447,95 @@ workflows:
       #################
       # EC2
       #################
-      # - build-test-app:
-      #     name: ec2_build-test-app
-      #     docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
-      #     docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}:${CIRCLE_SHA1}"
-      #     context: [CPE_ORBS_AWS]
-      #     filters: *filters
-      # - set-up-test-env:
-      #     name: ec2_set-up-test-env
-      #     filters: *filters
-      #     requires:
-      #       - ec2_build-test-app
-      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
-      #     terraform-config-dir: "tests/terraform_setup/ec2"
-      #     context: [CPE_ORBS_AWS]
-      # - set-up-run-task-test:
-      #     name: ec2_set-up-run-task-test
-      #     filters: *filters
-      #     requires:
-      #       - ec2_set-up-test-env
-      #     family-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360"
-      #     context: [CPE_ORBS_AWS]
-      # - aws-ecs/run-task:
-      #     name: ec2_run-task-test
-      #     filters: *filters
-      #     requires:
-      #       - ec2_set-up-run-task-test
-      #     cluster: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
-      #     aws-region: AWS_DEFAULT_REGION
-      #     task-definition: "${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360"
-      #     launch-type: "EC2"
-      #     awsvpc: false
-      #     overrides: '{"containerOverrides":[{"name": "${INTERPOLATION_TEST}", "memory": 512}]}'
-      #     context: [CPE_ORBS_AWS]
-      # - tear-down-run-task-test:
-      #     name: ec2_tear-down-run-task-test
-      #     filters: *filters
-      #     requires:
-      #       - ec2_run-task-test
-      #     family-name: ${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360
-      #     context: [CPE_ORBS_AWS]
+      - build-test-app:
+          name: ec2_build-test-app
+          docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+          docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}:${CIRCLE_SHA1}"
+          context: [CPE_ORBS_AWS]
+          filters: *filters
+      - set-up-test-env:
+          name: ec2_set-up-test-env
+          filters: *filters
+          requires:
+            - ec2_build-test-app
+          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
+          terraform-config-dir: "tests/terraform_setup/ec2"
+          context: [CPE_ORBS_AWS]
+      - set-up-run-task-test:
+          name: ec2_set-up-run-task-test
+          filters: *filters
+          requires:
+            - ec2_set-up-test-env
+          family-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360"
+          context: [CPE_ORBS_AWS]
+      - aws-ecs/run-task:
+          name: ec2_run-task-test
+          filters: *filters
+          requires:
+            - ec2_set-up-run-task-test
+          cluster: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
+          aws-region: AWS_DEFAULT_REGION
+          task-definition: "${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360"
+          launch-type: "EC2"
+          awsvpc: false
+          overrides: '{"containerOverrides":[{"name": "${INTERPOLATION_TEST}", "memory": 512}]}'
+          context: [CPE_ORBS_AWS]
+      - tear-down-run-task-test:
+          name: ec2_tear-down-run-task-test
+          filters: *filters
+          requires:
+            - ec2_run-task-test
+          family-name: ${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360
+          context: [CPE_ORBS_AWS]
 
-      # - test-service-update:
-      #     name: ec2_test-update-service-command
-      #     filters: *filters
-      #     requires:
-      #       - ec2_set-up-test-env
-      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
-      #     family-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
-      #     service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
-      #     docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
-      #     docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}:${CIRCLE_SHA1}"
-      #     context: [CPE_ORBS_AWS]
-      # - test-task-definition-update:
-      #     name: ec2_test-task-definition-update
-      #     family-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
-      #     context: [CPE_ORBS_AWS]
-      #     filters: *filters
-      #     requires:
-      #       - ec2_test-update-service-command
-      # - aws-ecs/deploy-service-update:
-      #     name: ec2_test-update-service-job
-      #     docker-image-for-job: cimg/python:3.10.4
-      #     context: [CPE_ORBS_AWS]
-      #     filters: *filters
-      #     requires:
-      #       - ec2_test-task-definition-update
-      #     aws-access-key-id: AWS_ACCESS_KEY_ID
-      #     aws-region: AWS_DEFAULT_REGION
-      #     family: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
-      #     service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
-      #     cluster-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
-      #     container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_EC2}-service,name=VERSION_INFO,value="Asterisk * expansion test ${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_EC2}-service,name=BUILD_DATE,value=$(date)'
-      #     verify-revision-is-deployed: true
-      #     fail-on-verification-timeout: false
-      #     post-steps:
-      #       - test-deployment:
-      #           service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
-      #           cluster-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
-      #           test-asterisk-expansion: true
+      - test-service-update:
+          name: ec2_test-update-service-command
+          filters: *filters
+          requires:
+            - ec2_set-up-test-env
+          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
+          family-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
+          service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
+          docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+          docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}:${CIRCLE_SHA1}"
+          context: [CPE_ORBS_AWS]
+      - test-task-definition-update:
+          name: ec2_test-task-definition-update
+          family-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
+          context: [CPE_ORBS_AWS]
+          filters: *filters
+          requires:
+            - ec2_test-update-service-command
+      - aws-ecs/deploy-service-update:
+          name: ec2_test-update-service-job
+          docker-image-for-job: cimg/python:3.10.4
+          context: [CPE_ORBS_AWS]
+          filters: *filters
+          requires:
+            - ec2_test-task-definition-update
+          aws-access-key-id: AWS_ACCESS_KEY_ID
+          aws-region: AWS_DEFAULT_REGION
+          family: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
+          service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
+          cluster-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
+          container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_EC2}-service,name=VERSION_INFO,value="Asterisk * expansion test ${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_EC2}-service,name=BUILD_DATE,value=$(date)'
+          verify-revision-is-deployed: true
+          fail-on-verification-timeout: false
+          post-steps:
+            - test-deployment:
+                service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
+                cluster-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
+                test-asterisk-expansion: true
 
-      # - tear-down-test-env:
-      #     name: ec2_tear-down-test-env
-      #     filters: *filters
-      #     requires:
-      #       - ec2_test-update-service-job
-      #       - ec2_tear-down-run-task-test
-      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
-      #     terraform-config-dir: "tests/terraform_setup/ec2"
-      #     context: [CPE_ORBS_AWS]
+      - tear-down-test-env:
+          name: ec2_tear-down-test-env
+          filters: *filters
+          requires:
+            - ec2_test-update-service-job
+            - ec2_tear-down-run-task-test
+          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
+          terraform-config-dir: "tests/terraform_setup/ec2"
+          context: [CPE_ORBS_AWS]
 
       # #################
       # # FargateSpot
@@ -550,97 +550,97 @@ workflows:
       #################
       # CodeDeploy
       #################
-      # - build-test-app:
-      #     name: codedeploy_fargate_build-test-app
-      #     docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
-      #     docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
-      #     context: [CPE_ORBS_AWS]
-      #     filters: *filters
-      # - set-up-test-env:
-      #     name: codedeploy_fargate_set-up-test-env
-      #     filters: *filters
-      #     requires:
-      #       - codedeploy_fargate_build-test-app
-      #     terraform-image: "hashicorp/terraform:1.1.9"
-      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
-      #     terraform-config-dir: "tests/terraform_setup/fargate_codedeploy"
-      #     context: [CPE_ORBS_AWS]
-      # - test-service-update:
-      #     name: codedeploy_fargate_test-update-service-command
-      #     filters: *filters
-      #     requires:
-      #       - codedeploy_fargate_set-up-test-env
-      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
-      #     family-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-      #     service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-      #     docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
-      #     docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
-      #     skip-service-update: true
-      #     context: [CPE_ORBS_AWS]
-      # - aws-ecs/deploy-service-update:
-      #     name: codedeploy_fargate_test-update-service-job
-      #     docker-image-for-job: cimg/python:3.10.4
-      #     filters: *filters
-      #     requires:
-      #       - codedeploy_fargate_test-update-service-command
-      #     aws-access-key-id: AWS_ACCESS_KEY_ID
-      #     aws-region: AWS_DEFAULT_REGION
-      #     family: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-      #     cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
-      #     container-image-name-updates: "container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,image-and-tag=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
-      #     container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=BUILD_DATE,value=$(date)'
-      #     deployment-controller: "CODE_DEPLOY"
-      #     codedeploy-application-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeployapp"
-      #     codedeploy-deployment-group-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
-      #     codedeploy-load-balanced-container-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-      #     codedeploy-load-balanced-container-port: 8080
-      #     verify-revision-is-deployed: false
-      #     context: [CPE_ORBS_AWS]
-      #     post-steps:
-      #       - wait-for-codedeploy-deployment:
-      #           application-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeployapp"
-      #           deployment-group-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
-      #       - test-deployment:
-      #           service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-      #           cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
-      #           delete-load-balancer: false
-      # - aws-ecs/deploy-service-update:
-      #     name: codedeploy_fargate_test-update-and-wait-service-job
-      #     docker-image-for-job: cimg/python:3.10.4
-      #     context: [CPE_ORBS_AWS]
-      #     filters: *filters
-      #     requires:
-      #       - codedeploy_fargate_test-update-service-job
-      #     aws-access-key-id: AWS_ACCESS_KEY_ID
-      #     aws-region: AWS_DEFAULT_REGION
-      #     family: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-      #     cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
-      #     container-image-name-updates: "container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,image-and-tag=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
-      #     container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=BUILD_DATE,value=$(date)'
-      #     deployment-controller: "CODE_DEPLOY"
-      #     codedeploy-application-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeployapp"
-      #     codedeploy-deployment-group-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
-      #     codedeploy-load-balanced-container-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-      #     codedeploy-load-balanced-container-port: 8080
-      #     verify-revision-is-deployed: true
-      #     verification-timeout: "12m"
-      #     post-steps:
-      #       - test-deployment:
-      #           service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-      #           cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
-      #           delete-load-balancer: true
-      #       - delete-service:
-      #           service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-      #           cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
-      # - tear-down-test-env:
-      #     name: codedeploy_fargate_tear-down-test-env
-      #     requires:
-      #       - codedeploy_fargate_test-update-and-wait-service-job
-      #     terraform-image: "hashicorp/terraform:1.1.9"
-      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
-      #     terraform-config-dir: "tests/terraform_setup/fargate_codedeploy"
-      #     context: [CPE_ORBS_AWS]
-      #     filters: *filters
+      - build-test-app:
+          name: codedeploy_fargate_build-test-app
+          docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+          docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
+          context: [CPE_ORBS_AWS]
+          filters: *filters
+      - set-up-test-env:
+          name: codedeploy_fargate_set-up-test-env
+          filters: *filters
+          requires:
+            - codedeploy_fargate_build-test-app
+          terraform-image: "hashicorp/terraform:1.1.9"
+          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
+          terraform-config-dir: "tests/terraform_setup/fargate_codedeploy"
+          context: [CPE_ORBS_AWS]
+      - test-service-update:
+          name: codedeploy_fargate_test-update-service-command
+          filters: *filters
+          requires:
+            - codedeploy_fargate_set-up-test-env
+          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
+          family-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+          service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+          docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+          docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
+          skip-service-update: true
+          context: [CPE_ORBS_AWS]
+      - aws-ecs/deploy-service-update:
+          name: codedeploy_fargate_test-update-service-job
+          docker-image-for-job: cimg/python:3.10.4
+          filters: *filters
+          requires:
+            - codedeploy_fargate_test-update-service-command
+          aws-access-key-id: AWS_ACCESS_KEY_ID
+          aws-region: AWS_DEFAULT_REGION
+          family: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+          cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+          container-image-name-updates: "container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,image-and-tag=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
+          container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=BUILD_DATE,value=$(date)'
+          deployment-controller: "CODE_DEPLOY"
+          codedeploy-application-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeployapp"
+          codedeploy-deployment-group-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
+          codedeploy-load-balanced-container-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+          codedeploy-load-balanced-container-port: 8080
+          verify-revision-is-deployed: false
+          context: [CPE_ORBS_AWS]
+          post-steps:
+            - wait-for-codedeploy-deployment:
+                application-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeployapp"
+                deployment-group-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
+            - test-deployment:
+                service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+                cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+                delete-load-balancer: false
+      - aws-ecs/deploy-service-update:
+          name: codedeploy_fargate_test-update-and-wait-service-job
+          docker-image-for-job: cimg/python:3.10.4
+          context: [CPE_ORBS_AWS]
+          filters: *filters
+          requires:
+            - codedeploy_fargate_test-update-service-job
+          aws-access-key-id: AWS_ACCESS_KEY_ID
+          aws-region: AWS_DEFAULT_REGION
+          family: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+          cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+          container-image-name-updates: "container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,image-and-tag=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
+          container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=BUILD_DATE,value=$(date)'
+          deployment-controller: "CODE_DEPLOY"
+          codedeploy-application-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeployapp"
+          codedeploy-deployment-group-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
+          codedeploy-load-balanced-container-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+          codedeploy-load-balanced-container-port: 8080
+          verify-revision-is-deployed: true
+          verification-timeout: "12m"
+          post-steps:
+            - test-deployment:
+                service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+                cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+                delete-load-balancer: true
+            - delete-service:
+                service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+                cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+      - tear-down-test-env:
+          name: codedeploy_fargate_tear-down-test-env
+          requires:
+            - codedeploy_fargate_test-update-and-wait-service-job
+          terraform-image: "hashicorp/terraform:1.1.9"
+          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
+          terraform-config-dir: "tests/terraform_setup/fargate_codedeploy"
+          context: [CPE_ORBS_AWS]
+          filters: *filters
       - orb-tools/pack:
           filters: *filters
       - orb-tools/publish:
@@ -649,10 +649,10 @@ workflows:
           pub-type: production
           requires:
             - orb-tools/pack
-            # - ec2_tear-down-test-env
+            - ec2_tear-down-test-env
             - fargate_tear-down-test-env  
-            # - codedeploy_fargate_tear-down-test-env
-            # - integration-test-ecs-cli-install
+            - codedeploy_fargate_tear-down-test-env
+            - integration-test-ecs-cli-install
           context: orb-publisher
           filters:
             branches:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -359,12 +359,12 @@ workflows:
   test-deploy:
     jobs:
       # Make sure to include "filters: *filters" in every test job you want to run as part of your deployment.
-      - integration-test-ecs-cli-install:
-          version: "v1.9.0"
-          matrix:
-            parameters:
-              executor: [linux, mac]
-          filters: *filters
+      # - integration-test-ecs-cli-install:
+      #     version: "v1.9.0"
+      #     matrix:
+      #       parameters:
+      #         executor: [linux, mac]
+      #     filters: *filters
       #################
       # Fargate
       #################
@@ -447,95 +447,95 @@ workflows:
       #################
       # EC2
       #################
-      - build-test-app:
-          name: ec2_build-test-app
-          docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
-          docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}:${CIRCLE_SHA1}"
-          context: [CPE_ORBS_AWS]
-          filters: *filters
-      - set-up-test-env:
-          name: ec2_set-up-test-env
-          filters: *filters
-          requires:
-            - ec2_build-test-app
-          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
-          terraform-config-dir: "tests/terraform_setup/ec2"
-          context: [CPE_ORBS_AWS]
-      - set-up-run-task-test:
-          name: ec2_set-up-run-task-test
-          filters: *filters
-          requires:
-            - ec2_set-up-test-env
-          family-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360"
-          context: [CPE_ORBS_AWS]
-      - aws-ecs/run-task:
-          name: ec2_run-task-test
-          filters: *filters
-          requires:
-            - ec2_set-up-run-task-test
-          cluster: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
-          aws-region: AWS_DEFAULT_REGION
-          task-definition: "${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360"
-          launch-type: "EC2"
-          awsvpc: false
-          overrides: '{"containerOverrides":[{"name": "sleep", "memory": 512}]}'
-          context: [CPE_ORBS_AWS]
-      - tear-down-run-task-test:
-          name: ec2_tear-down-run-task-test
-          filters: *filters
-          requires:
-            - ec2_run-task-test
-          family-name: ${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360
-          context: [CPE_ORBS_AWS]
+      # - build-test-app:
+      #     name: ec2_build-test-app
+      #     docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+      #     docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}:${CIRCLE_SHA1}"
+      #     context: [CPE_ORBS_AWS]
+      #     filters: *filters
+      # - set-up-test-env:
+      #     name: ec2_set-up-test-env
+      #     filters: *filters
+      #     requires:
+      #       - ec2_build-test-app
+      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
+      #     terraform-config-dir: "tests/terraform_setup/ec2"
+      #     context: [CPE_ORBS_AWS]
+      # - set-up-run-task-test:
+      #     name: ec2_set-up-run-task-test
+      #     filters: *filters
+      #     requires:
+      #       - ec2_set-up-test-env
+      #     family-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360"
+      #     context: [CPE_ORBS_AWS]
+      # - aws-ecs/run-task:
+      #     name: ec2_run-task-test
+      #     filters: *filters
+      #     requires:
+      #       - ec2_set-up-run-task-test
+      #     cluster: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
+      #     aws-region: AWS_DEFAULT_REGION
+      #     task-definition: "${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360"
+      #     launch-type: "EC2"
+      #     awsvpc: false
+      #     overrides: '{"containerOverrides":[{"name": "${INTERPOLATION_TEST}", "memory": 512}]}'
+      #     context: [CPE_ORBS_AWS]
+      # - tear-down-run-task-test:
+      #     name: ec2_tear-down-run-task-test
+      #     filters: *filters
+      #     requires:
+      #       - ec2_run-task-test
+      #     family-name: ${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360
+      #     context: [CPE_ORBS_AWS]
 
-      - test-service-update:
-          name: ec2_test-update-service-command
-          filters: *filters
-          requires:
-            - ec2_set-up-test-env
-          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
-          family-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
-          service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
-          docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
-          docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}:${CIRCLE_SHA1}"
-          context: [CPE_ORBS_AWS]
-      - test-task-definition-update:
-          name: ec2_test-task-definition-update
-          family-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
-          context: [CPE_ORBS_AWS]
-          filters: *filters
-          requires:
-            - ec2_test-update-service-command
-      - aws-ecs/deploy-service-update:
-          name: ec2_test-update-service-job
-          docker-image-for-job: cimg/python:3.10.4
-          context: [CPE_ORBS_AWS]
-          filters: *filters
-          requires:
-            - ec2_test-task-definition-update
-          aws-access-key-id: AWS_ACCESS_KEY_ID
-          aws-region: AWS_DEFAULT_REGION
-          family: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
-          service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
-          cluster-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
-          container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_EC2}-service,name=VERSION_INFO,value="Asterisk * expansion test ${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_EC2}-service,name=BUILD_DATE,value=$(date)'
-          verify-revision-is-deployed: true
-          fail-on-verification-timeout: false
-          post-steps:
-            - test-deployment:
-                service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
-                cluster-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
-                test-asterisk-expansion: true
+      # - test-service-update:
+      #     name: ec2_test-update-service-command
+      #     filters: *filters
+      #     requires:
+      #       - ec2_set-up-test-env
+      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
+      #     family-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
+      #     service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
+      #     docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+      #     docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}:${CIRCLE_SHA1}"
+      #     context: [CPE_ORBS_AWS]
+      # - test-task-definition-update:
+      #     name: ec2_test-task-definition-update
+      #     family-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
+      #     context: [CPE_ORBS_AWS]
+      #     filters: *filters
+      #     requires:
+      #       - ec2_test-update-service-command
+      # - aws-ecs/deploy-service-update:
+      #     name: ec2_test-update-service-job
+      #     docker-image-for-job: cimg/python:3.10.4
+      #     context: [CPE_ORBS_AWS]
+      #     filters: *filters
+      #     requires:
+      #       - ec2_test-task-definition-update
+      #     aws-access-key-id: AWS_ACCESS_KEY_ID
+      #     aws-region: AWS_DEFAULT_REGION
+      #     family: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
+      #     service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
+      #     cluster-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
+      #     container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_EC2}-service,name=VERSION_INFO,value="Asterisk * expansion test ${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_EC2}-service,name=BUILD_DATE,value=$(date)'
+      #     verify-revision-is-deployed: true
+      #     fail-on-verification-timeout: false
+      #     post-steps:
+      #       - test-deployment:
+      #           service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
+      #           cluster-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
+      #           test-asterisk-expansion: true
 
-      - tear-down-test-env:
-          name: ec2_tear-down-test-env
-          filters: *filters
-          requires:
-            - ec2_test-update-service-job
-            - ec2_tear-down-run-task-test
-          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
-          terraform-config-dir: "tests/terraform_setup/ec2"
-          context: [CPE_ORBS_AWS]
+      # - tear-down-test-env:
+      #     name: ec2_tear-down-test-env
+      #     filters: *filters
+      #     requires:
+      #       - ec2_test-update-service-job
+      #       - ec2_tear-down-run-task-test
+      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
+      #     terraform-config-dir: "tests/terraform_setup/ec2"
+      #     context: [CPE_ORBS_AWS]
 
       # #################
       # # FargateSpot
@@ -550,97 +550,97 @@ workflows:
       #################
       # CodeDeploy
       #################
-      - build-test-app:
-          name: codedeploy_fargate_build-test-app
-          docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
-          docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
-          context: [CPE_ORBS_AWS]
-          filters: *filters
-      - set-up-test-env:
-          name: codedeploy_fargate_set-up-test-env
-          filters: *filters
-          requires:
-            - codedeploy_fargate_build-test-app
-          terraform-image: "hashicorp/terraform:1.1.9"
-          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
-          terraform-config-dir: "tests/terraform_setup/fargate_codedeploy"
-          context: [CPE_ORBS_AWS]
-      - test-service-update:
-          name: codedeploy_fargate_test-update-service-command
-          filters: *filters
-          requires:
-            - codedeploy_fargate_set-up-test-env
-          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
-          family-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-          service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-          docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
-          docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
-          skip-service-update: true
-          context: [CPE_ORBS_AWS]
-      - aws-ecs/deploy-service-update:
-          name: codedeploy_fargate_test-update-service-job
-          docker-image-for-job: cimg/python:3.10.4
-          filters: *filters
-          requires:
-            - codedeploy_fargate_test-update-service-command
-          aws-access-key-id: AWS_ACCESS_KEY_ID
-          aws-region: AWS_DEFAULT_REGION
-          family: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-          cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
-          container-image-name-updates: "container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,image-and-tag=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
-          container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=BUILD_DATE,value=$(date)'
-          deployment-controller: "CODE_DEPLOY"
-          codedeploy-application-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeployapp"
-          codedeploy-deployment-group-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
-          codedeploy-load-balanced-container-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-          codedeploy-load-balanced-container-port: 8080
-          verify-revision-is-deployed: false
-          context: [CPE_ORBS_AWS]
-          post-steps:
-            - wait-for-codedeploy-deployment:
-                application-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeployapp"
-                deployment-group-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
-            - test-deployment:
-                service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-                cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
-                delete-load-balancer: false
-      - aws-ecs/deploy-service-update:
-          name: codedeploy_fargate_test-update-and-wait-service-job
-          docker-image-for-job: cimg/python:3.10.4
-          context: [CPE_ORBS_AWS]
-          filters: *filters
-          requires:
-            - codedeploy_fargate_test-update-service-job
-          aws-access-key-id: AWS_ACCESS_KEY_ID
-          aws-region: AWS_DEFAULT_REGION
-          family: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-          cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
-          container-image-name-updates: "container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,image-and-tag=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
-          container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=BUILD_DATE,value=$(date)'
-          deployment-controller: "CODE_DEPLOY"
-          codedeploy-application-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeployapp"
-          codedeploy-deployment-group-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
-          codedeploy-load-balanced-container-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-          codedeploy-load-balanced-container-port: 8080
-          verify-revision-is-deployed: true
-          verification-timeout: "12m"
-          post-steps:
-            - test-deployment:
-                service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-                cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
-                delete-load-balancer: true
-            - delete-service:
-                service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-                cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
-      - tear-down-test-env:
-          name: codedeploy_fargate_tear-down-test-env
-          requires:
-            - codedeploy_fargate_test-update-and-wait-service-job
-          terraform-image: "hashicorp/terraform:1.1.9"
-          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
-          terraform-config-dir: "tests/terraform_setup/fargate_codedeploy"
-          context: [CPE_ORBS_AWS]
-          filters: *filters
+      # - build-test-app:
+      #     name: codedeploy_fargate_build-test-app
+      #     docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+      #     docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
+      #     context: [CPE_ORBS_AWS]
+      #     filters: *filters
+      # - set-up-test-env:
+      #     name: codedeploy_fargate_set-up-test-env
+      #     filters: *filters
+      #     requires:
+      #       - codedeploy_fargate_build-test-app
+      #     terraform-image: "hashicorp/terraform:1.1.9"
+      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
+      #     terraform-config-dir: "tests/terraform_setup/fargate_codedeploy"
+      #     context: [CPE_ORBS_AWS]
+      # - test-service-update:
+      #     name: codedeploy_fargate_test-update-service-command
+      #     filters: *filters
+      #     requires:
+      #       - codedeploy_fargate_set-up-test-env
+      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
+      #     family-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+      #     service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+      #     docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+      #     docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
+      #     skip-service-update: true
+      #     context: [CPE_ORBS_AWS]
+      # - aws-ecs/deploy-service-update:
+      #     name: codedeploy_fargate_test-update-service-job
+      #     docker-image-for-job: cimg/python:3.10.4
+      #     filters: *filters
+      #     requires:
+      #       - codedeploy_fargate_test-update-service-command
+      #     aws-access-key-id: AWS_ACCESS_KEY_ID
+      #     aws-region: AWS_DEFAULT_REGION
+      #     family: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+      #     cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+      #     container-image-name-updates: "container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,image-and-tag=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
+      #     container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=BUILD_DATE,value=$(date)'
+      #     deployment-controller: "CODE_DEPLOY"
+      #     codedeploy-application-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeployapp"
+      #     codedeploy-deployment-group-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
+      #     codedeploy-load-balanced-container-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+      #     codedeploy-load-balanced-container-port: 8080
+      #     verify-revision-is-deployed: false
+      #     context: [CPE_ORBS_AWS]
+      #     post-steps:
+      #       - wait-for-codedeploy-deployment:
+      #           application-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeployapp"
+      #           deployment-group-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
+      #       - test-deployment:
+      #           service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+      #           cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+      #           delete-load-balancer: false
+      # - aws-ecs/deploy-service-update:
+      #     name: codedeploy_fargate_test-update-and-wait-service-job
+      #     docker-image-for-job: cimg/python:3.10.4
+      #     context: [CPE_ORBS_AWS]
+      #     filters: *filters
+      #     requires:
+      #       - codedeploy_fargate_test-update-service-job
+      #     aws-access-key-id: AWS_ACCESS_KEY_ID
+      #     aws-region: AWS_DEFAULT_REGION
+      #     family: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+      #     cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+      #     container-image-name-updates: "container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,image-and-tag=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
+      #     container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=BUILD_DATE,value=$(date)'
+      #     deployment-controller: "CODE_DEPLOY"
+      #     codedeploy-application-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeployapp"
+      #     codedeploy-deployment-group-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
+      #     codedeploy-load-balanced-container-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+      #     codedeploy-load-balanced-container-port: 8080
+      #     verify-revision-is-deployed: true
+      #     verification-timeout: "12m"
+      #     post-steps:
+      #       - test-deployment:
+      #           service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+      #           cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+      #           delete-load-balancer: true
+      #       - delete-service:
+      #           service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+      #           cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+      # - tear-down-test-env:
+      #     name: codedeploy_fargate_tear-down-test-env
+      #     requires:
+      #       - codedeploy_fargate_test-update-and-wait-service-job
+      #     terraform-image: "hashicorp/terraform:1.1.9"
+      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
+      #     terraform-config-dir: "tests/terraform_setup/fargate_codedeploy"
+      #     context: [CPE_ORBS_AWS]
+      #     filters: *filters
       - orb-tools/pack:
           filters: *filters
       - orb-tools/publish:
@@ -649,10 +649,10 @@ workflows:
           pub-type: production
           requires:
             - orb-tools/pack
-            - ec2_tear-down-test-env
+            # - ec2_tear-down-test-env
             - fargate_tear-down-test-env  
-            - codedeploy_fargate_tear-down-test-env
-            - integration-test-ecs-cli-install
+            # - codedeploy_fargate_tear-down-test-env
+            # - integration-test-ecs-cli-install
           context: orb-publisher
           filters:
             branches:

--- a/src/commands/run-task.yml
+++ b/src/commands/run-task.yml
@@ -90,9 +90,6 @@ parameters:
   overrides:
     description: >
       A list of container overrides in JSON format that specify the name of a container in the specified task definition and the overrides it should receive.
-
-      Double quotes in the JSON should be escaped e.g.:
-      {\\\"containerOverrides\\\":[{\\\"name\\\": \\\"sleep\\\", \\\"memory\\\":512}]}
     type: string
     default: ''
   tags:

--- a/src/jobs/run-task.yml
+++ b/src/jobs/run-task.yml
@@ -121,9 +121,6 @@ parameters:
       A list of container overrides in JSON format that specify the name of
       a container in the specified task definition and the overrides it
       should receive.
-      Double quotes in the JSON should be escaped e.g.:
-      {\\\"containerOverrides\\\":[{\\\"name\\\": \\\"sleep\\\", \\\"memory\\\":
-      512}]}
     type: string
     default: ''
   tags:

--- a/src/scripts/run-task.sh
+++ b/src/scripts/run-task.sh
@@ -6,11 +6,10 @@ ECS_PARAM_PROFILE_NAME=$(eval echo "$ECS_PARAM_PROFILE_NAME")
 
 if ! command -v envsubst && [[ "$ECS_PARAM_OVERRIDES" == *"\${"* ]]; then
     echo "Installing envsubst."
-    $SUDO apt update 
-    $SUDO apt install gettext
-    echo "$ECS_PARAM_OVERRIDES" > json.txt
-    ECS_PARAM_OVERRIDES=$(envsubst < json.txt)
-    $SUDO rm json.txt
+    curl -L https://github.com/a8m/envsubst/releases/download/v1.2.0/envsubst-"$(uname -s)"-"$(uname -m)" -o envsubst
+    $SUDO chmod +x envsubst
+    $SUDO mv envsubst /usr/local/bin
+    ECS_PARAM_OVERRIDES=$(echo "${ECS_PARAM_OVERRIDES}" | envsubst)
 fi
 
 set -o noglob

--- a/src/scripts/run-task.sh
+++ b/src/scripts/run-task.sh
@@ -1,7 +1,17 @@
+if [[ $EUID == 0 ]]; then export SUDO=""; else export SUDO="sudo"; fi
 # These variables are evaluated so the config file may contain and pass in environment variables to the parameters.
 ECS_PARAM_CLUSTER_NAME=$(eval echo "$ECS_PARAM_CLUSTER_NAME")
 ECS_PARAM_TASK_DEF=$(eval echo "$ECS_PARAM_TASK_DEF")
 ECS_PARAM_PROFILE_NAME=$(eval echo "$ECS_PARAM_PROFILE_NAME")
+
+if ! command -v envsubst && [[ "$ECS_PARAM_OVERRIDES" == *"\${"* ]]; then
+    echo "Installing envsubst."
+    $SUDO apt update 
+    $SUDO apt install gettext
+    echo "$ECS_PARAM_OVERRIDES" > json.txt
+    ECS_PARAM_OVERRIDES=$(envsubst < json.txt)
+    $SUDO rm json.txt
+fi
 
 set -o noglob
 if [ -n "$ECS_PARAM_PLATFORM_VERSION" ]; then


### PR DESCRIPTION
This PR addresses the interpolation issue for the `overrides` parameter. It enables users to use an environment variable in the  `overrides` parameter's `json` string. If your parameter contains an environment variable, `envsubst` is used to interpolate the `json` string. If the image used does not have `envsubst` installed, the script will it automatically download and install it.