### PR TITLE
feat: implement run-task-output parameter

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -359,90 +359,90 @@ workflows:
   test-deploy:
     jobs:
       # Make sure to include "filters: *filters" in every test job you want to run as part of your deployment.
-      # - integration-test-ecs-cli-install:
-      #     version: "v1.9.0"
-      #     matrix:
-      #       parameters:
-      #         executor: [linux, mac]
-      #     filters: *filters
+      - integration-test-ecs-cli-install:
+          version: "v1.9.0"
+          matrix:
+            parameters:
+              executor: [linux, mac]
+          filters: *filters
       #################
       # Fargate
       #################
-      # - build-test-app:
-      #     name: fargate_build-test-app
-      #     docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
-      #     docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}:${CIRCLE_SHA1}"
-      #     context: [CPE_ORBS_AWS]
-      #     filters: *filters
-      # - set-up-test-env:
-      #     name: fargate_set-up-test-env
-      #     filters: *filters
-      #     requires:
-      #       - fargate_build-test-app
-      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
-      #     terraform-config-dir: "tests/terraform_setup/fargate"
-      #     context: [CPE_ORBS_AWS]
-      # - test-service-update:
-      #     name: fargate_test-update-service-command
-      #     filters: *filters
-      #     requires:
-      #       - fargate_set-up-test-env
-      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
-      #     family-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
-      #     service-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
-      #     docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
-      #     docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}:${CIRCLE_SHA1}"
-      #     context: [CPE_ORBS_AWS]
-      # - aws-ecs/deploy-service-update:
-      #     name: fargate_test-update-service-job
-      #     docker-image-for-job: cimg/python:3.10.4
-      #     filters: *filters
-      #     requires:
-      #       - fargate_test-update-service-command
-      #     aws-access-key-id: AWS_ACCESS_KEY_ID
-      #     aws-region: AWS_DEFAULT_REGION
-      #     profile-name: "ECS_TEST_PROFILE"
-      #     family: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
-      #     cluster-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
-      #     container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service,name=BUILD_DATE,value=$(date)'
-      #     # test the force-new-deployment flag
-      #     force-new-deployment: true
-      #     verify-revision-is-deployed: true
-      #     max-poll-attempts: 40
-      #     poll-interval: 10
-      #     context: [CPE_ORBS_AWS]
-      #     post-steps:
-      #       - test-deployment:
-      #           service-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
-      #           cluster-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
-      # - aws-ecs/deploy-service-update:
-      #     name: fargate_test-update-service-skip-registration
-      #     docker-image-for-job: cimg/python:3.10.4
-      #     filters: *filters
-      #     requires:
-      #       - fargate_test-update-service-job
-      #     aws-access-key-id: AWS_ACCESS_KEY_ID
-      #     aws-region: AWS_DEFAULT_REGION
-      #     profile-name: "ECS_TEST_PROFILE"
-      #     family: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
-      #     cluster-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
-      #     # test skipping registration of a new task definition
-      #     skip-task-definition-registration: true
-      #     # test the enable-circuit-breaker flag
-      #     enable-circuit-breaker: true
-      #     verify-revision-is-deployed: true
-      #     max-poll-attempts: 40
-      #     poll-interval: 10
-      #     context: [CPE_ORBS_AWS]
-      # - tear-down-test-env:
-      #     name: fargate_tear-down-test-env
-      #     filters: *filters
-      #     requires:
-      #       - fargate_test-update-service-skip-registration
-      #       - test-fargatespot
-      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
-      #     terraform-config-dir: "tests/terraform_setup/fargate"
-      #     context: [CPE_ORBS_AWS]
+      - build-test-app:
+          name: fargate_build-test-app
+          docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+          docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}:${CIRCLE_SHA1}"
+          context: [CPE_ORBS_AWS]
+          filters: *filters
+      - set-up-test-env:
+          name: fargate_set-up-test-env
+          filters: *filters
+          requires:
+            - fargate_build-test-app
+          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
+          terraform-config-dir: "tests/terraform_setup/fargate"
+          context: [CPE_ORBS_AWS]
+      - test-service-update:
+          name: fargate_test-update-service-command
+          filters: *filters
+          requires:
+            - fargate_set-up-test-env
+          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
+          family-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
+          service-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
+          docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+          docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}:${CIRCLE_SHA1}"
+          context: [CPE_ORBS_AWS]
+      - aws-ecs/deploy-service-update:
+          name: fargate_test-update-service-job
+          docker-image-for-job: cimg/python:3.10.4
+          filters: *filters
+          requires:
+            - fargate_test-update-service-command
+          aws-access-key-id: AWS_ACCESS_KEY_ID
+          aws-region: AWS_DEFAULT_REGION
+          profile-name: "ECS_TEST_PROFILE"
+          family: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
+          cluster-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
+          container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service,name=BUILD_DATE,value=$(date)'
+          # test the force-new-deployment flag
+          force-new-deployment: true
+          verify-revision-is-deployed: true
+          max-poll-attempts: 40
+          poll-interval: 10
+          context: [CPE_ORBS_AWS]
+          post-steps:
+            - test-deployment:
+                service-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
+                cluster-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
+      - aws-ecs/deploy-service-update:
+          name: fargate_test-update-service-skip-registration
+          docker-image-for-job: cimg/python:3.10.4
+          filters: *filters
+          requires:
+            - fargate_test-update-service-job
+          aws-access-key-id: AWS_ACCESS_KEY_ID
+          aws-region: AWS_DEFAULT_REGION
+          profile-name: "ECS_TEST_PROFILE"
+          family: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
+          cluster-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
+          # test skipping registration of a new task definition
+          skip-task-definition-registration: true
+          # test the enable-circuit-breaker flag
+          enable-circuit-breaker: true
+          verify-revision-is-deployed: true
+          max-poll-attempts: 40
+          poll-interval: 10
+          context: [CPE_ORBS_AWS]
+      - tear-down-test-env:
+          name: fargate_tear-down-test-env
+          filters: *filters
+          requires:
+            - fargate_test-update-service-skip-registration
+            - test-fargatespot
+          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
+          terraform-config-dir: "tests/terraform_setup/fargate"
+          context: [CPE_ORBS_AWS]
 
       #################
       # EC2
@@ -542,106 +542,106 @@ workflows:
       # # FargateSpot
       # #################
 
-      # - test-fargatespot:
-      #     context: [CPE_ORBS_AWS]
-      #     filters: *filters
-      #     requires:
-      #       - fargate_set-up-test-env
+      - test-fargatespot:
+          context: [CPE_ORBS_AWS]
+          filters: *filters
+          requires:
+            - fargate_set-up-test-env
 
       #################
       # CodeDeploy
       #################
-      # - build-test-app:
-      #     name: codedeploy_fargate_build-test-app
-      #     docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
-      #     docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
-      #     context: [CPE_ORBS_AWS]
-      #     filters: *filters
-      # - set-up-test-env:
-      #     name: codedeploy_fargate_set-up-test-env
-      #     filters: *filters
-      #     requires:
-      #       - codedeploy_fargate_build-test-app
-      #     terraform-image: "hashicorp/terraform:1.1.9"
-      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
-      #     terraform-config-dir: "tests/terraform_setup/fargate_codedeploy"
-      #     context: [CPE_ORBS_AWS]
-      # - test-service-update:
-      #     name: codedeploy_fargate_test-update-service-command
-      #     filters: *filters
-      #     requires:
-      #       - codedeploy_fargate_set-up-test-env
-      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
-      #     family-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-      #     service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-      #     docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
-      #     docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
-      #     skip-service-update: true
-      #     context: [CPE_ORBS_AWS]
-      # - aws-ecs/deploy-service-update:
-      #     name: codedeploy_fargate_test-update-service-job
-      #     docker-image-for-job: cimg/python:3.10.4
-      #     filters: *filters
-      #     requires:
-      #       - codedeploy_fargate_test-update-service-command
-      #     aws-access-key-id: AWS_ACCESS_KEY_ID
-      #     aws-region: AWS_DEFAULT_REGION
-      #     family: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-      #     cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
-      #     container-image-name-updates: "container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,image-and-tag=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
-      #     container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=BUILD_DATE,value=$(date)'
-      #     deployment-controller: "CODE_DEPLOY"
-      #     codedeploy-application-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeployapp"
-      #     codedeploy-deployment-group-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
-      #     codedeploy-load-balanced-container-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-      #     codedeploy-load-balanced-container-port: 8080
-      #     verify-revision-is-deployed: false
-      #     context: [CPE_ORBS_AWS]
-      #     post-steps:
-      #       - wait-for-codedeploy-deployment:
-      #           application-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeployapp"
-      #           deployment-group-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
-      #       - test-deployment:
-      #           service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-      #           cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
-      #           delete-load-balancer: false
-      # - aws-ecs/deploy-service-update:
-      #     name: codedeploy_fargate_test-update-and-wait-service-job
-      #     docker-image-for-job: cimg/python:3.10.4
-      #     context: [CPE_ORBS_AWS]
-      #     filters: *filters
-      #     requires:
-      #       - codedeploy_fargate_test-update-service-job
-      #     aws-access-key-id: AWS_ACCESS_KEY_ID
-      #     aws-region: AWS_DEFAULT_REGION
-      #     family: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-      #     cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
-      #     container-image-name-updates: "container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,image-and-tag=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
-      #     container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=BUILD_DATE,value=$(date)'
-      #     deployment-controller: "CODE_DEPLOY"
-      #     codedeploy-application-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeployapp"
-      #     codedeploy-deployment-group-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
-      #     codedeploy-load-balanced-container-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-      #     codedeploy-load-balanced-container-port: 8080
-      #     verify-revision-is-deployed: true
-      #     verification-timeout: "12m"
-      #     post-steps:
-      #       - test-deployment:
-      #           service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-      #           cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
-      #           delete-load-balancer: true
-      #       - delete-service:
-      #           service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-      #           cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
-      # - tear-down-test-env:
-      #     name: codedeploy_fargate_tear-down-test-env
-      #     requires:
-      #       - codedeploy_fargate_test-update-and-wait-service-job
-      #     terraform-image: "hashicorp/terraform:1.1.9"
-      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
-      #     terraform-config-dir: "tests/terraform_setup/fargate_codedeploy"
-      #     context: [CPE_ORBS_AWS]
-      #     filters: *filters
+      - build-test-app:
+          name: codedeploy_fargate_build-test-app
+          docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+          docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
+          context: [CPE_ORBS_AWS]
+          filters: *filters
+      - set-up-test-env:
+          name: codedeploy_fargate_set-up-test-env
+          filters: *filters
+          requires:
+            - codedeploy_fargate_build-test-app
+          terraform-image: "hashicorp/terraform:1.1.9"
+          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
+          terraform-config-dir: "tests/terraform_setup/fargate_codedeploy"
+          context: [CPE_ORBS_AWS]
+      - test-service-update:
+          name: codedeploy_fargate_test-update-service-command
+          filters: *filters
+          requires:
+            - codedeploy_fargate_set-up-test-env
+          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
+          family-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+          service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+          docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+          docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
+          skip-service-update: true
+          context: [CPE_ORBS_AWS]
+      - aws-ecs/deploy-service-update:
+          name: codedeploy_fargate_test-update-service-job
+          docker-image-for-job: cimg/python:3.10.4
+          filters: *filters
+          requires:
+            - codedeploy_fargate_test-update-service-command
+          aws-access-key-id: AWS_ACCESS_KEY_ID
+          aws-region: AWS_DEFAULT_REGION
+          family: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+          cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+          container-image-name-updates: "container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,image-and-tag=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
+          container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=BUILD_DATE,value=$(date)'
+          deployment-controller: "CODE_DEPLOY"
+          codedeploy-application-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeployapp"
+          codedeploy-deployment-group-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
+          codedeploy-load-balanced-container-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+          codedeploy-load-balanced-container-port: 8080
+          verify-revision-is-deployed: false
+          context: [CPE_ORBS_AWS]
+          post-steps:
+            - wait-for-codedeploy-deployment:
+                application-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeployapp"
+                deployment-group-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
+            - test-deployment:
+                service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+                cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+                delete-load-balancer: false
+      - aws-ecs/deploy-service-update:
+          name: codedeploy_fargate_test-update-and-wait-service-job
+          docker-image-for-job: cimg/python:3.10.4
+          context: [CPE_ORBS_AWS]
+          filters: *filters
+          requires:
+            - codedeploy_fargate_test-update-service-job
+          aws-access-key-id: AWS_ACCESS_KEY_ID
+          aws-region: AWS_DEFAULT_REGION
+          family: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+          cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+          container-image-name-updates: "container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,image-and-tag=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
+          container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=BUILD_DATE,value=$(date)'
+          deployment-controller: "CODE_DEPLOY"
+          codedeploy-application-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeployapp"
+          codedeploy-deployment-group-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
+          codedeploy-load-balanced-container-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+          codedeploy-load-balanced-container-port: 8080
+          verify-revision-is-deployed: true
+          verification-timeout: "12m"
+          post-steps:
+            - test-deployment:
+                service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+                cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+                delete-load-balancer: true
+            - delete-service:
+                service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+                cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+      - tear-down-test-env:
+          name: codedeploy_fargate_tear-down-test-env
+          requires:
+            - codedeploy_fargate_test-update-and-wait-service-job
+          terraform-image: "hashicorp/terraform:1.1.9"
+          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
+          terraform-config-dir: "tests/terraform_setup/fargate_codedeploy"
+          context: [CPE_ORBS_AWS]
+          filters: *filters
       - orb-tools/pack:
           filters: *filters
       - orb-tools/publish:
@@ -651,9 +651,9 @@ workflows:
           requires:
             - orb-tools/pack
             - ec2_tear-down-test-env
-            # - fargate_tear-down-test-env  
-            # - codedeploy_fargate_tear-down-test-env
-            # - integration-test-ecs-cli-install
+            - fargate_tear-down-test-env  
+            - codedeploy_fargate_tear-down-test-env
+            - integration-test-ecs-cli-install
           context: orb-publisher
           filters:
             branches:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -359,90 +359,90 @@ workflows:
   test-deploy:
     jobs:
       # Make sure to include "filters: *filters" in every test job you want to run as part of your deployment.
-      - integration-test-ecs-cli-install:
-          version: "v1.9.0"
-          matrix:
-            parameters:
-              executor: [linux, mac]
-          filters: *filters
+      # - integration-test-ecs-cli-install:
+      #     version: "v1.9.0"
+      #     matrix:
+      #       parameters:
+      #         executor: [linux, mac]
+      #     filters: *filters
       #################
       # Fargate
       #################
-      - build-test-app:
-          name: fargate_build-test-app
-          docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
-          docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}:${CIRCLE_SHA1}"
-          context: [CPE_ORBS_AWS]
-          filters: *filters
-      - set-up-test-env:
-          name: fargate_set-up-test-env
-          filters: *filters
-          requires:
-            - fargate_build-test-app
-          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
-          terraform-config-dir: "tests/terraform_setup/fargate"
-          context: [CPE_ORBS_AWS]
-      - test-service-update:
-          name: fargate_test-update-service-command
-          filters: *filters
-          requires:
-            - fargate_set-up-test-env
-          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
-          family-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
-          service-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
-          docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
-          docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}:${CIRCLE_SHA1}"
-          context: [CPE_ORBS_AWS]
-      - aws-ecs/deploy-service-update:
-          name: fargate_test-update-service-job
-          docker-image-for-job: cimg/python:3.10.4
-          filters: *filters
-          requires:
-            - fargate_test-update-service-command
-          aws-access-key-id: AWS_ACCESS_KEY_ID
-          aws-region: AWS_DEFAULT_REGION
-          profile-name: "ECS_TEST_PROFILE"
-          family: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
-          cluster-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
-          container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service,name=BUILD_DATE,value=$(date)'
-          # test the force-new-deployment flag
-          force-new-deployment: true
-          verify-revision-is-deployed: true
-          max-poll-attempts: 40
-          poll-interval: 10
-          context: [CPE_ORBS_AWS]
-          post-steps:
-            - test-deployment:
-                service-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
-                cluster-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
-      - aws-ecs/deploy-service-update:
-          name: fargate_test-update-service-skip-registration
-          docker-image-for-job: cimg/python:3.10.4
-          filters: *filters
-          requires:
-            - fargate_test-update-service-job
-          aws-access-key-id: AWS_ACCESS_KEY_ID
-          aws-region: AWS_DEFAULT_REGION
-          profile-name: "ECS_TEST_PROFILE"
-          family: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
-          cluster-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
-          # test skipping registration of a new task definition
-          skip-task-definition-registration: true
-          # test the enable-circuit-breaker flag
-          enable-circuit-breaker: true
-          verify-revision-is-deployed: true
-          max-poll-attempts: 40
-          poll-interval: 10
-          context: [CPE_ORBS_AWS]
-      - tear-down-test-env:
-          name: fargate_tear-down-test-env
-          filters: *filters
-          requires:
-            - fargate_test-update-service-skip-registration
-            - test-fargatespot
-          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
-          terraform-config-dir: "tests/terraform_setup/fargate"
-          context: [CPE_ORBS_AWS]
+      # - build-test-app:
+      #     name: fargate_build-test-app
+      #     docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+      #     docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}:${CIRCLE_SHA1}"
+      #     context: [CPE_ORBS_AWS]
+      #     filters: *filters
+      # - set-up-test-env:
+      #     name: fargate_set-up-test-env
+      #     filters: *filters
+      #     requires:
+      #       - fargate_build-test-app
+      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
+      #     terraform-config-dir: "tests/terraform_setup/fargate"
+      #     context: [CPE_ORBS_AWS]
+      # - test-service-update:
+      #     name: fargate_test-update-service-command
+      #     filters: *filters
+      #     requires:
+      #       - fargate_set-up-test-env
+      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
+      #     family-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
+      #     service-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
+      #     docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+      #     docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}:${CIRCLE_SHA1}"
+      #     context: [CPE_ORBS_AWS]
+      # - aws-ecs/deploy-service-update:
+      #     name: fargate_test-update-service-job
+      #     docker-image-for-job: cimg/python:3.10.4
+      #     filters: *filters
+      #     requires:
+      #       - fargate_test-update-service-command
+      #     aws-access-key-id: AWS_ACCESS_KEY_ID
+      #     aws-region: AWS_DEFAULT_REGION
+      #     profile-name: "ECS_TEST_PROFILE"
+      #     family: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
+      #     cluster-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
+      #     container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service,name=BUILD_DATE,value=$(date)'
+      #     # test the force-new-deployment flag
+      #     force-new-deployment: true
+      #     verify-revision-is-deployed: true
+      #     max-poll-attempts: 40
+      #     poll-interval: 10
+      #     context: [CPE_ORBS_AWS]
+      #     post-steps:
+      #       - test-deployment:
+      #           service-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
+      #           cluster-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
+      # - aws-ecs/deploy-service-update:
+      #     name: fargate_test-update-service-skip-registration
+      #     docker-image-for-job: cimg/python:3.10.4
+      #     filters: *filters
+      #     requires:
+      #       - fargate_test-update-service-job
+      #     aws-access-key-id: AWS_ACCESS_KEY_ID
+      #     aws-region: AWS_DEFAULT_REGION
+      #     profile-name: "ECS_TEST_PROFILE"
+      #     family: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
+      #     cluster-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
+      #     # test skipping registration of a new task definition
+      #     skip-task-definition-registration: true
+      #     # test the enable-circuit-breaker flag
+      #     enable-circuit-breaker: true
+      #     verify-revision-is-deployed: true
+      #     max-poll-attempts: 40
+      #     poll-interval: 10
+      #     context: [CPE_ORBS_AWS]
+      # - tear-down-test-env:
+      #     name: fargate_tear-down-test-env
+      #     filters: *filters
+      #     requires:
+      #       - fargate_test-update-service-skip-registration
+      #       - test-fargatespot
+      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
+      #     terraform-config-dir: "tests/terraform_setup/fargate"
+      #     context: [CPE_ORBS_AWS]
 
       #################
       # EC2
@@ -478,6 +478,7 @@ workflows:
           task-definition: "${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360"
           launch-type: "EC2"
           awsvpc: false
+          run-task-output: "run-task-output.json"
           overrides: '{"containerOverrides":[{"name": "${INTERPOLATION_TEST}", "memory": 512}]}'
           context: [CPE_ORBS_AWS]
       - tear-down-run-task-test:
@@ -541,106 +542,106 @@ workflows:
       # # FargateSpot
       # #################
 
-      - test-fargatespot:
-          context: [CPE_ORBS_AWS]
-          filters: *filters
-          requires:
-            - fargate_set-up-test-env
+      # - test-fargatespot:
+      #     context: [CPE_ORBS_AWS]
+      #     filters: *filters
+      #     requires:
+      #       - fargate_set-up-test-env
 
       #################
       # CodeDeploy
       #################
-      - build-test-app:
-          name: codedeploy_fargate_build-test-app
-          docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
-          docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
-          context: [CPE_ORBS_AWS]
-          filters: *filters
-      - set-up-test-env:
-          name: codedeploy_fargate_set-up-test-env
-          filters: *filters
-          requires:
-            - codedeploy_fargate_build-test-app
-          terraform-image: "hashicorp/terraform:1.1.9"
-          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
-          terraform-config-dir: "tests/terraform_setup/fargate_codedeploy"
-          context: [CPE_ORBS_AWS]
-      - test-service-update:
-          name: codedeploy_fargate_test-update-service-command
-          filters: *filters
-          requires:
-            - codedeploy_fargate_set-up-test-env
-          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
-          family-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-          service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-          docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
-          docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
-          skip-service-update: true
-          context: [CPE_ORBS_AWS]
-      - aws-ecs/deploy-service-update:
-          name: codedeploy_fargate_test-update-service-job
-          docker-image-for-job: cimg/python:3.10.4
-          filters: *filters
-          requires:
-            - codedeploy_fargate_test-update-service-command
-          aws-access-key-id: AWS_ACCESS_KEY_ID
-          aws-region: AWS_DEFAULT_REGION
-          family: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-          cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
-          container-image-name-updates: "container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,image-and-tag=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
-          container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=BUILD_DATE,value=$(date)'
-          deployment-controller: "CODE_DEPLOY"
-          codedeploy-application-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeployapp"
-          codedeploy-deployment-group-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
-          codedeploy-load-balanced-container-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-          codedeploy-load-balanced-container-port: 8080
-          verify-revision-is-deployed: false
-          context: [CPE_ORBS_AWS]
-          post-steps:
-            - wait-for-codedeploy-deployment:
-                application-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeployapp"
-                deployment-group-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
-            - test-deployment:
-                service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-                cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
-                delete-load-balancer: false
-      - aws-ecs/deploy-service-update:
-          name: codedeploy_fargate_test-update-and-wait-service-job
-          docker-image-for-job: cimg/python:3.10.4
-          context: [CPE_ORBS_AWS]
-          filters: *filters
-          requires:
-            - codedeploy_fargate_test-update-service-job
-          aws-access-key-id: AWS_ACCESS_KEY_ID
-          aws-region: AWS_DEFAULT_REGION
-          family: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-          cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
-          container-image-name-updates: "container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,image-and-tag=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
-          container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=BUILD_DATE,value=$(date)'
-          deployment-controller: "CODE_DEPLOY"
-          codedeploy-application-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeployapp"
-          codedeploy-deployment-group-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
-          codedeploy-load-balanced-container-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-          codedeploy-load-balanced-container-port: 8080
-          verify-revision-is-deployed: true
-          verification-timeout: "12m"
-          post-steps:
-            - test-deployment:
-                service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-                cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
-                delete-load-balancer: true
-            - delete-service:
-                service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-                cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
-      - tear-down-test-env:
-          name: codedeploy_fargate_tear-down-test-env
-          requires:
-            - codedeploy_fargate_test-update-and-wait-service-job
-          terraform-image: "hashicorp/terraform:1.1.9"
-          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
-          terraform-config-dir: "tests/terraform_setup/fargate_codedeploy"
-          context: [CPE_ORBS_AWS]
-          filters: *filters
+      # - build-test-app:
+      #     name: codedeploy_fargate_build-test-app
+      #     docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+      #     docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
+      #     context: [CPE_ORBS_AWS]
+      #     filters: *filters
+      # - set-up-test-env:
+      #     name: codedeploy_fargate_set-up-test-env
+      #     filters: *filters
+      #     requires:
+      #       - codedeploy_fargate_build-test-app
+      #     terraform-image: "hashicorp/terraform:1.1.9"
+      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
+      #     terraform-config-dir: "tests/terraform_setup/fargate_codedeploy"
+      #     context: [CPE_ORBS_AWS]
+      # - test-service-update:
+      #     name: codedeploy_fargate_test-update-service-command
+      #     filters: *filters
+      #     requires:
+      #       - codedeploy_fargate_set-up-test-env
+      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
+      #     family-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+      #     service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+      #     docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+      #     docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
+      #     skip-service-update: true
+      #     context: [CPE_ORBS_AWS]
+      # - aws-ecs/deploy-service-update:
+      #     name: codedeploy_fargate_test-update-service-job
+      #     docker-image-for-job: cimg/python:3.10.4
+      #     filters: *filters
+      #     requires:
+      #       - codedeploy_fargate_test-update-service-command
+      #     aws-access-key-id: AWS_ACCESS_KEY_ID
+      #     aws-region: AWS_DEFAULT_REGION
+      #     family: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+      #     cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+      #     container-image-name-updates: "container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,image-and-tag=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
+      #     container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=BUILD_DATE,value=$(date)'
+      #     deployment-controller: "CODE_DEPLOY"
+      #     codedeploy-application-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeployapp"
+      #     codedeploy-deployment-group-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
+      #     codedeploy-load-balanced-container-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+      #     codedeploy-load-balanced-container-port: 8080
+      #     verify-revision-is-deployed: false
+      #     context: [CPE_ORBS_AWS]
+      #     post-steps:
+      #       - wait-for-codedeploy-deployment:
+      #           application-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeployapp"
+      #           deployment-group-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
+      #       - test-deployment:
+      #           service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+      #           cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+      #           delete-load-balancer: false
+      # - aws-ecs/deploy-service-update:
+      #     name: codedeploy_fargate_test-update-and-wait-service-job
+      #     docker-image-for-job: cimg/python:3.10.4
+      #     context: [CPE_ORBS_AWS]
+      #     filters: *filters
+      #     requires:
+      #       - codedeploy_fargate_test-update-service-job
+      #     aws-access-key-id: AWS_ACCESS_KEY_ID
+      #     aws-region: AWS_DEFAULT_REGION
+      #     family: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+      #     cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+      #     container-image-name-updates: "container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,image-and-tag=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
+      #     container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=BUILD_DATE,value=$(date)'
+      #     deployment-controller: "CODE_DEPLOY"
+      #     codedeploy-application-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeployapp"
+      #     codedeploy-deployment-group-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
+      #     codedeploy-load-balanced-container-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+      #     codedeploy-load-balanced-container-port: 8080
+      #     verify-revision-is-deployed: true
+      #     verification-timeout: "12m"
+      #     post-steps:
+      #       - test-deployment:
+      #           service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+      #           cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+      #           delete-load-balancer: true
+      #       - delete-service:
+      #           service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+      #           cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+      # - tear-down-test-env:
+      #     name: codedeploy_fargate_tear-down-test-env
+      #     requires:
+      #       - codedeploy_fargate_test-update-and-wait-service-job
+      #     terraform-image: "hashicorp/terraform:1.1.9"
+      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
+      #     terraform-config-dir: "tests/terraform_setup/fargate_codedeploy"
+      #     context: [CPE_ORBS_AWS]
+      #     filters: *filters
       - orb-tools/pack:
           filters: *filters
       - orb-tools/publish:
@@ -650,9 +651,9 @@ workflows:
           requires:
             - orb-tools/pack
             - ec2_tear-down-test-env
-            - fargate_tear-down-test-env  
-            - codedeploy_fargate_tear-down-test-env
-            - integration-test-ecs-cli-install
+            # - fargate_tear-down-test-env  
+            # - codedeploy_fargate_tear-down-test-env
+            # - integration-test-ecs-cli-install
           context: orb-publisher
           filters:
             branches:

--- a/src/commands/run-task.yml
+++ b/src/commands/run-task.yml
@@ -113,6 +113,10 @@ parameters:
     description: AWS profile name to be configured.
     type: string
     default: ''
+  run-task-output:
+    description: |
+          Specifies a local file on to save the output from the aws ecs run-task command.
+    type: string
 steps:
   - run:
       name: Run Task
@@ -137,3 +141,4 @@ steps:
         ECS_PARAM_PROPAGATE_TAGS: <<parameters.propagate-tags>>
         ECS_PARAM_CAPACITY_PROVIDER_STRATEGY: <<parameters.capacity-provider-strategy>>
         ECS_PARAM_PROFILE_NAME: <<parameters.profile-name>>
+        ECS_PARAM_RUN_OUTPUT: <<parameters.run-task-output>>

--- a/src/commands/run-task.yml
+++ b/src/commands/run-task.yml
@@ -115,7 +115,7 @@ parameters:
     default: ''
   run-task-output:
     description: |
-          Specifies a local json file to save the output logs from the aws ecs run-task command. This will enable users to extract information like task-arn's, task-id's and more from the output.
+          Specifies a local json file to save the output logs from the aws ecs run-task command. Use tools like JQ to read and parse this information such as "task-arns" and "task-ids"
     type: string
     default: ''
 steps:

--- a/src/commands/run-task.yml
+++ b/src/commands/run-task.yml
@@ -115,7 +115,7 @@ parameters:
     default: ''
   run-task-output:
     description: |
-          Specifies a local file on to save the output from the aws ecs run-task command.
+          Specifies a local json file to save the output logs from the aws ecs run-task command. This will enable users to extract information like task-arn's, task-id's and more from the output.
     type: string
     default: ''
 steps:

--- a/src/commands/run-task.yml
+++ b/src/commands/run-task.yml
@@ -117,6 +117,7 @@ parameters:
     description: |
           Specifies a local file on to save the output from the aws ecs run-task command.
     type: string
+    default: ''
 steps:
   - run:
       name: Run Task
@@ -141,4 +142,4 @@ steps:
         ECS_PARAM_PROPAGATE_TAGS: <<parameters.propagate-tags>>
         ECS_PARAM_CAPACITY_PROVIDER_STRATEGY: <<parameters.capacity-provider-strategy>>
         ECS_PARAM_PROFILE_NAME: <<parameters.profile-name>>
-        ECS_PARAM_RUN_OUTPUT: <<parameters.run-task-output>>
+        ECS_PARAM_RUN_TASK_OUTPUT: <<parameters.run-task-output>>

--- a/src/jobs/run-task.yml
+++ b/src/jobs/run-task.yml
@@ -151,7 +151,7 @@ parameters:
     default: ""
   run-task-output:
     description: |
-          Specifies a local file on to save the output from the aws ecs run-task command.
+          Specifies a local json file to save the output logs from the aws ecs run-task command. This will enable users to extract information like task-arn's, task-id's and more from the output.
     type: string
     default: ''
 steps:

--- a/src/jobs/run-task.yml
+++ b/src/jobs/run-task.yml
@@ -151,7 +151,7 @@ parameters:
     default: ""
   run-task-output:
     description: |
-          Specifies a local json file to save the output logs from the aws ecs run-task command. This will enable users to extract information like task-arn's, task-id's and more from the output.
+          Specifies a local json file to save the output logs from the aws ecs run-task command. Use tools like JQ to read and parse this information such as "task-arns" and "task-ids"
     type: string
     default: ''
 steps:

--- a/src/jobs/run-task.yml
+++ b/src/jobs/run-task.yml
@@ -152,7 +152,8 @@ parameters:
   run-task-output:
     description: |
           Specifies a local file on to save the output from the aws ecs run-task command.
-    type: string   
+    type: string
+    default: ''
 steps:
   - aws-cli/setup:
       aws-access-key-id: << parameters.aws-access-key-id >>
@@ -180,3 +181,5 @@ steps:
       capacity-provider-strategy: << parameters.capacity-provider-strategy >>
       profile-name: << parameters.profile-name >>
       run-task-output: <<parameters.run-task-output>>
+  - store_artifacts:
+      path: run-task-output.json

--- a/src/jobs/run-task.yml
+++ b/src/jobs/run-task.yml
@@ -149,6 +149,10 @@ parameters:
       If a `capacity-provider-strategy` is specified, the `launch-type` parameter must be set to an empty string.
     type: string
     default: ""
+  run-task-output:
+    description: |
+          Specifies a local file on to save the output from the aws ecs run-task command.
+    type: string   
 steps:
   - aws-cli/setup:
       aws-access-key-id: << parameters.aws-access-key-id >>
@@ -175,3 +179,4 @@ steps:
       propagate-tags: << parameters.propagate-tags >>
       capacity-provider-strategy: << parameters.capacity-provider-strategy >>
       profile-name: << parameters.profile-name >>
+      run-task-output: <<parameters.run-task-output>>

--- a/src/jobs/run-task.yml
+++ b/src/jobs/run-task.yml
@@ -181,5 +181,3 @@ steps:
       capacity-provider-strategy: << parameters.capacity-provider-strategy >>
       profile-name: << parameters.profile-name >>
       run-task-output: <<parameters.run-task-output>>
-  - store_artifacts:
-      path: run-task-output.json

--- a/src/scripts/run-task.sh
+++ b/src/scripts/run-task.sh
@@ -91,5 +91,6 @@ set -- "$@" --cluster "$ECS_PARAM_CLUSTER_NAME"
 
 if [ -n "${ECS_PARAM_RUN_TASK_OUTPUT}" ]; then
     aws ecs run-task "$@" >> "${ECS_PARAM_RUN_TASK_OUTPUT}"
+else    
+    aws ecs run-task "$@"
 fi
-aws ecs run-task "$@"

--- a/src/scripts/run-task.sh
+++ b/src/scripts/run-task.sh
@@ -88,6 +88,7 @@ echo "Setting --task-definition"
 set -- "$@" --task-definition "$ECS_PARAM_TASK_DEF"
 echo "Setting --cluster"
 set -- "$@" --cluster "$ECS_PARAM_CLUSTER_NAME"
+
 if [ -n "${ECS_PARAM_RUN_TASK_OUTPUT}" ]; then
     aws ecs run-task "$@" >> "${ECS_PARAM_RUN_TASK_OUTPUT}"
 fi

--- a/src/scripts/run-task.sh
+++ b/src/scripts/run-task.sh
@@ -88,5 +88,7 @@ echo "Setting --task-definition"
 set -- "$@" --task-definition "$ECS_PARAM_TASK_DEF"
 echo "Setting --cluster"
 set -- "$@" --cluster "$ECS_PARAM_CLUSTER_NAME"
-
+if [ -n "${ECS_PARAM_RUN_TASK_OUTPUT}" ]; then
+    aws ecs run-task "$@" >> "${ECS_PARAM_RUN_TASK_OUTPUT}"
+fi
 aws ecs run-task "$@"

--- a/src/scripts/run-task.sh
+++ b/src/scripts/run-task.sh
@@ -90,7 +90,7 @@ echo "Setting --cluster"
 set -- "$@" --cluster "$ECS_PARAM_CLUSTER_NAME"
 
 if [ -n "${ECS_PARAM_RUN_TASK_OUTPUT}" ]; then
-    aws ecs run-task "$@" >> "${ECS_PARAM_RUN_TASK_OUTPUT}"
+    aws ecs run-task "$@" | tee "${ECS_PARAM_RUN_TASK_OUTPUT}"
 else    
     aws ecs run-task "$@"
 fi


### PR DESCRIPTION
This PR is the implementation of the `run-task-output` parameter. It enables users to specify a local `json` file to store the output logs from the `aws ecs run-task` command. The file can be used to extract information like a `task-arn`, `task-id` and more using `jq`
