### PR TITLE
feat: added deploy-ecs-scheduled-task command

### DIFF
--- a/src/commands/deploy-ecs-scheduled-task.yml
+++ b/src/commands/deploy-ecs-scheduled-task.yml
@@ -1,0 +1,13 @@
+description: |
+  Deploy an ECS Scheduled Task Rule after updating a task definition. The update-task-definition command must be run first.
+
+parameters:
+  rule-name:
+    description: The name of the scheduled task's rule to update.
+    type: string
+steps:
+  - run:
+      name: Deploy rule with updated task definition
+      environment:
+        ECS_PARAM_RULE_NAME: <<parameters.rule-name>>
+      command: <<include(scripts/deploy-ecs-scheduled-task.sh)>>

--- a/src/jobs/update-task-definition-from-json.yml
+++ b/src/jobs/update-task-definition-from-json.yml
@@ -48,6 +48,6 @@ steps:
       profile-name: << parameters.profile-name >>
   - when:
       condition: <<parameters.deploy-scheduled-task>>
-      steps: 
+      steps:
         - deploy-ecs-scheduled-task:
             rule-name: <<parameters.rule-name>>

--- a/src/jobs/update-task-definition-from-json.yml
+++ b/src/jobs/update-task-definition-from-json.yml
@@ -29,6 +29,14 @@ parameters:
     description: |
       Location of your .json task definition file (relative or absolute).
     type: string
+  deploy-scheduled-task:
+    description: >
+      Set this parameter to true to deploy updated task definition to a scheduled task rule.
+    type: boolean
+    default: false
+  rule-name:
+    description: The name of the scheduled task's rule to update. Must be a valid ECS Rule.
+    type: string
 steps:
   - aws-cli/setup:
       aws-access-key-id: << parameters.aws-access-key-id >>
@@ -38,3 +46,8 @@ steps:
   - update-task-definition-from-json:
       task-definition-json: << parameters.task-definition-json >>
       profile-name: << parameters.profile-name >>
+  - when:
+      condition: <<parameters.deploy-scheduled-task>>
+      steps: 
+        - deploy-ecs-scheduled-task:
+            rule-name: <<parameters.rule-name>>

--- a/src/jobs/update-task-definition.yml
+++ b/src/jobs/update-task-definition.yml
@@ -86,7 +86,6 @@ steps:
       profile-name: << parameters.profile-name >>
   - when:
       condition: <<parameters.deploy-scheduled-task>>
-      steps: 
+      steps:
         - deploy-ecs-scheduled-task:
             rule-name: <<parameters.rule-name>>
-  

--- a/src/jobs/update-task-definition.yml
+++ b/src/jobs/update-task-definition.yml
@@ -65,6 +65,14 @@ parameters:
       Values should not contain commas.
     type: string
     default: ''
+  deploy-scheduled-task:
+    description: >
+      Set this parameter to true to deploy updated task definition to a scheduled task rule.
+    type: boolean
+    default: false
+  rule-name:
+    description: The name of the scheduled task's rule to update. Must be a valid ECS Rule.
+    type: string
 steps:
   - aws-cli/setup:
       aws-access-key-id: << parameters.aws-access-key-id >>
@@ -76,3 +84,9 @@ steps:
       container-image-name-updates: << parameters.container-image-name-updates >>
       container-env-var-updates: << parameters.container-env-var-updates >>
       profile-name: << parameters.profile-name >>
+  - when:
+      condition: <<parameters.deploy-scheduled-task>>
+      steps: 
+        - deploy-ecs-scheduled-task:
+            rule-name: <<parameters.rule-name>>
+  

--- a/src/scripts/deploy-ecs-scheduled-task.sh
+++ b/src/scripts/deploy-ecs-scheduled-task.sh
@@ -1,0 +1,19 @@
+td_arn=$CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN
+
+if [ -z "$td_arn" ]; then
+    echo "Updated task definition not found. Please run update-task-definition command before deploy-ecs-scheduled-task"
+    exit 1
+fi
+
+CLI_OUTPUT_FILE=$(mktmp cli-output.json.XXXX)
+CLI_INPUT_FILE=$(mktmp cli-input.json.XXXX)
+
+aws events list-targets-by-rule --rule "$ECS_PARAM_RULE_NAME" --output json > "$CLI_OUTPUT_FILE"
+
+if < "$CLI_OUTPUT_FILE" jq ' .Targets[] | has("EcsParameters")' | grep "false"; then
+    echo "Invalid ECS Rule. $ECS_PARAM_RULE_NAME does not contain EcsParameters key. Please create a valid ECS Rule and try again"
+    exit 1
+fi
+
+< "$CLI_OUTPUT_FILE" jq --arg td_arn "$td_arn" '.Targets[].EcsParameters.TaskDefinitionArn |= $td_arn' > "$CLI_INPUT_FILE"
+aws events put-targets --cli-input-json "$(cat "$CLI_INPUT_FILE")"

--- a/src/scripts/update-bluegreen-service-via-task-def.sh
+++ b/src/scripts/update-bluegreen-service-via-task-def.sh
@@ -8,7 +8,7 @@ ECS_PARAM_CD_LOAD_BALANCED_CONTAINER_NAME=$(eval echo "$ECS_PARAM_CD_LOAD_BALANC
 DEPLOYED_REVISION="${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN}"
 
 if [ "$ECS_PARAM_ENABLE_CIRCUIT_BREAKER" == "1" ] && [ "$ECS_PARAM_VERIFY_REV_DEPLOY" == "0" ]; then
-    echo "enable-circuit-breaker is set to true, but verify-revision-deploy is set to false.  verfiy-revision-deploy is must be set to true to use enable-circuit-breaker."
+    echo "enable-circuit-breaker is set to true, but verify-revision-deploy is set to false.  verfiy-revision-deploy must be set to true to use enable-circuit-breaker."
     exit 1
 fi
 


### PR DESCRIPTION
This PR implements the `deploy-ecs-scheduled-task` command. It enables users to deploy a valid ECS Scheduled Task Rule using the task definition  arn generated from running the `update-task-definition` command. The `update-task-definition` command must be run prior to running `deploy-ecs-scheduled-task`.