### PR TITLE
fix!: renamed cluster-name parameter to cluster for consistency 

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -696,7 +696,7 @@ commands:
           name: Delete ECS service
           command: |
             aws ecs delete-service \
-              --cluster << parameters.cluster: >> \
+              --cluster << parameters.cluster>> \
               --service << parameters.service-name >> \
               --force
   test-deployment:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -213,7 +213,7 @@ jobs:
             - aws-ecs/update-service:
                 family: "<< parameters.family-name >>"
                 service-name: "<< parameters.service-name >>"
-                cluster-name: "<< parameters.aws-resource-name-prefix >>-cluster"
+                cluster: "<< parameters.aws-resource-name-prefix >>-cluster"
                 container-image-name-updates: "container=<< parameters.aws-resource-name-prefix >>-service,image-and-tag=$FULL_IMAGE_NAME"
                 container-env-var-updates: 'container=<< parameters.aws-resource-name-prefix >>-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=<< parameters.aws-resource-name-prefix >>-service,name=BUILD_DATE,value=$(date)'
                 verify-revision-is-deployed: true
@@ -221,7 +221,7 @@ jobs:
                 profile-name: "<<parameters.profile-name>>"
             - test-deployment:
                 service-name: "<< parameters.aws-resource-name-prefix >>-service"
-                cluster-name: "<< parameters.aws-resource-name-prefix >>-cluster"
+                cluster: "<< parameters.aws-resource-name-prefix >>-cluster"
   test-task-definition-update:
     docker:
       - image: cimg/python:3.10.4
@@ -403,7 +403,7 @@ workflows:
           aws-region: AWS_DEFAULT_REGION
           profile-name: "ECS_TEST_PROFILE"
           family: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
-          cluster-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
+          cluster: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
           container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service,name=BUILD_DATE,value=$(date)'
           # test the force-new-deployment flag
           force-new-deployment: true
@@ -414,7 +414,7 @@ workflows:
           post-steps:
             - test-deployment:
                 service-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
-                cluster-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
+                cluster: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
       - aws-ecs/deploy-service-update:
           name: fargate_test-update-service-skip-registration
           docker-image-for-job: cimg/python:3.10.4
@@ -425,7 +425,7 @@ workflows:
           aws-region: AWS_DEFAULT_REGION
           profile-name: "ECS_TEST_PROFILE"
           family: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
-          cluster-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
+          cluster: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
           # test skipping registration of a new task definition
           skip-task-definition-registration: true
           # test the enable-circuit-breaker flag
@@ -518,14 +518,14 @@ workflows:
           aws-region: AWS_DEFAULT_REGION
           family: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
           service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
-          cluster-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
+          cluster: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
           container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_EC2}-service,name=VERSION_INFO,value="Asterisk * expansion test ${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_EC2}-service,name=BUILD_DATE,value=$(date)'
           verify-revision-is-deployed: true
           fail-on-verification-timeout: false
           post-steps:
             - test-deployment:
                 service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
-                cluster-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
+                cluster: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
                 test-asterisk-expansion: true
 
       - tear-down-test-env:
@@ -587,7 +587,7 @@ workflows:
           aws-access-key-id: AWS_ACCESS_KEY_ID
           aws-region: AWS_DEFAULT_REGION
           family: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-          cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+          cluster: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
           container-image-name-updates: "container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,image-and-tag=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
           container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=BUILD_DATE,value=$(date)'
           deployment-controller: "CODE_DEPLOY"
@@ -603,7 +603,7 @@ workflows:
                 deployment-group-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
             - test-deployment:
                 service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-                cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+                cluster: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
                 delete-load-balancer: false
       - aws-ecs/deploy-service-update:
           name: codedeploy_fargate_test-update-and-wait-service-job
@@ -615,7 +615,7 @@ workflows:
           aws-access-key-id: AWS_ACCESS_KEY_ID
           aws-region: AWS_DEFAULT_REGION
           family: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-          cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+          cluster: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
           container-image-name-updates: "container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,image-and-tag=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
           container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=BUILD_DATE,value=$(date)'
           deployment-controller: "CODE_DEPLOY"
@@ -628,11 +628,11 @@ workflows:
           post-steps:
             - test-deployment:
                 service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-                cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+                cluster: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
                 delete-load-balancer: true
             - delete-service:
                 service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-                cluster-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+                cluster: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
       - tear-down-test-env:
           name: codedeploy_fargate_tear-down-test-env
           requires:
@@ -688,7 +688,7 @@ commands:
       service-name:
         description: "Name of the ECS service"
         type: string
-      cluster-name:
+      cluster:
         description: "Name of the cluster"
         type: string
     steps:
@@ -696,7 +696,7 @@ commands:
           name: Delete ECS service
           command: |
             aws ecs delete-service \
-              --cluster << parameters.cluster-name >> \
+              --cluster << parameters.cluster: >> \
               --service << parameters.service-name >> \
               --force
   test-deployment:
@@ -705,7 +705,7 @@ commands:
       service-name:
         description: "Name of the ECS service"
         type: string
-      cluster-name:
+      cluster:
         description: "Name of the cluster"
         type: string
       test-asterisk-expansion:
@@ -721,7 +721,7 @@ commands:
           name: Test deployment (for orb testing and is not part of the orb)
           command: |-
             set -x
-            TARGET_GROUP_ARN=$(aws ecs describe-services --cluster << parameters.cluster-name >> --services << parameters.service-name >> | jq -r '.services[0].loadBalancers[0].targetGroupArn')
+            TARGET_GROUP_ARN=$(aws ecs describe-services --cluster << parameters.cluster >> --services << parameters.service-name >> | jq -r '.services[0].loadBalancers[0].targetGroupArn')
             ELB_ARN=$(aws elbv2 describe-target-groups --target-group-arns $TARGET_GROUP_ARN | jq -r '.TargetGroups[0].LoadBalancerArns[0]')
             ELB_DNS_NAME=$(aws elbv2 describe-load-balancers --load-balancer-arns $ELB_ARN | jq -r '.LoadBalancers[0].DNSName')
             echo "ELB DNS NAME: $ELB_DNS_NAME"

--- a/src/commands/update-service.yml
+++ b/src/commands/update-service.yml
@@ -4,7 +4,7 @@ parameters:
   family:
     description: Name of the task definition's family.
     type: string
-  cluster-name:
+  cluster:
     description: The short name or full ARN of the cluster that hosts the service.
     type: string
   service-name:
@@ -201,7 +201,7 @@ steps:
               ECS_PARAM_SERVICE_NAME: <<parameters.service-name>>
               ECS_PARAM_FAMILY: <<parameters.family>>
               ECS_PARAM_FORCE_NEW_DEPLOY: <<parameters.force-new-deployment>>
-              ECS_PARAM_CLUSTER_NAME: <<parameters.cluster-name>>
+              ECS_PARAM_CLUSTER_NAME: <<parameters.cluster>>
               ECS_PARAM_PROFILE_NAME: <<parameters.profile-name>>
               ECS_PARAM_ENABLE_CIRCUIT_BREAKER: <<parameters.enable-circuit-breaker>>
 
@@ -215,7 +215,7 @@ steps:
       steps:
         - verify-revision-is-deployed:
             family: << parameters.family >>
-            cluster-name: << parameters.cluster-name >>
+            cluster: << parameters.cluster >>
             service-name: << parameters.service-name >>
             task-definition-arn: $CCI_ORB_AWS_ECS_DEPLOYED_REVISION
             max-poll-attempts: << parameters.max-poll-attempts >>

--- a/src/commands/verify-revision-is-deployed.yml
+++ b/src/commands/verify-revision-is-deployed.yml
@@ -5,7 +5,7 @@ parameters:
   family:
     description: Name of the task definition's family.
     type: string
-  cluster-name:
+  cluster:
     description: The short name or full ARN of the cluster that hosts the service.
     type: string
   service-name:
@@ -45,7 +45,7 @@ steps:
         ECS_PARAM_FAMILY: <<parameters.family>>
         ECS_PARAM_TASK_DEF_ARN: <<parameters.task-definition-arn>>
         ECS_PARAM_MAX_POLL_ATTEMPTS: <<parameters.max-poll-attempts>>
-        ECS_PARAM_CLUSTER_NAME: <<parameters.cluster-name>>
+        ECS_PARAM_CLUSTER_NAME: <<parameters.cluster>>
         ECS_PARAM_POLL_INTERVAL: <<parameters.poll-interval>>
         ECS_PARAM_FAIL_ON_VERIFY_TIMEOUT: <<parameters.fail-on-verification-timeout>>
         ECS_PARAM_PROFILE_NAME: <<parameters.profile-name>>

--- a/src/examples/deploy-service-update.yml
+++ b/src/examples/deploy-service-update.yml
@@ -16,5 +16,5 @@ usage:
             requires:
               - aws-ecr/build-and-push-image
             family: '${MY_APP_PREFIX}-service'
-            cluster-name: '${MY_APP_PREFIX}-cluster'
+            cluster: '${MY_APP_PREFIX}-cluster'
             container-image-name-updates: 'container=${MY_APP_PREFIX}-service,tag=${CIRCLE_SHA1}'

--- a/src/examples/update-service.yml
+++ b/src/examples/update-service.yml
@@ -18,7 +18,7 @@ usage:
             aws-region: AWS_DEFAULT_REGION
         - aws-ecs/update-service:
             family: '${MY_APP_PREFIX}-service'
-            cluster-name: '${MY_APP_PREFIX}-cluster'
+            cluster: '${MY_APP_PREFIX}-cluster'
             container-image-name-updates: 'container=${MY_APP_PREFIX}-service,tag=stable'
   workflows:
     deploy:

--- a/src/examples/verify-revision-deplopyment.yml
+++ b/src/examples/verify-revision-deplopyment.yml
@@ -26,7 +26,7 @@ usage:
               $BASH_ENV
         - aws-ecs/verify-revision-is-deployed:
             family: '${MY_APP_PREFIX}-service'
-            cluster-name: '${MY_APP_PREFIX}-cluster'
+            cluster: '${MY_APP_PREFIX}-cluster'
             task-definition-arn: '${TASK_DEFINITION_ARN}'
   workflows:
     test-workflow:

--- a/src/jobs/deploy-service-update.yml
+++ b/src/jobs/deploy-service-update.yml
@@ -29,7 +29,7 @@ parameters:
   family:
     description: Name of the task definition's family.
     type: string
-  cluster-name:
+  cluster:
     description: The short name or full ARN of the cluster that hosts the service.
     type: string
   service-name:
@@ -193,7 +193,7 @@ steps:
       profile-name: << parameters.profile-name >>
   - update-service:
       family: << parameters.family >>
-      cluster-name: << parameters.cluster-name >>
+      cluster: << parameters.cluster >>
       service-name: << parameters.service-name >>
       deployment-controller: << parameters.deployment-controller >>
       enable-circuit-breaker: << parameters.enable-circuit-breaker >>


### PR DESCRIPTION
This PR renames the `cluster-name` parameter to `cluster` for consistency within all commands and with `AWS`