### PR TITLE
feat: implement capacity provider strategy

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -595,6 +595,9 @@ workflows:
           codedeploy-deployment-group-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
           codedeploy-load-balanced-container-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
           codedeploy-load-balanced-container-port: 8080
+          codedeploy-capacity-provider-name: "FARGATE"
+          codedeploy-capacity-provider-base: "1"
+          codedeploy-capacity-provider-weight: "0"
           verify-revision-is-deployed: false
           context: [CPE_ORBS_AWS]
           post-steps:
@@ -633,15 +636,17 @@ workflows:
       #       - delete-service:
       #           service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
       #           cluster: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
-      # - tear-down-test-env:
-      #     name: codedeploy_fargate_tear-down-test-env
-      #     requires:
-      #       - codedeploy_fargate_test-update-and-wait-service-job
-      #     terraform-image: "hashicorp/terraform:1.1.9"
-      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
-      #     terraform-config-dir: "tests/terraform_setup/fargate_codedeploy"
-      #     context: [CPE_ORBS_AWS]
-      #     filters: *filters
+      - tear-down-test-env:
+          name: codedeploy_fargate_tear-down-test-env
+          # requires:
+          #   - codedeploy_fargate_test-update-and-wait-service-job
+          requires:
+            - codedeploy_fargate_test-update-service-job
+          terraform-image: "hashicorp/terraform:1.1.9"
+          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
+          terraform-config-dir: "tests/terraform_setup/fargate_codedeploy"
+          context: [CPE_ORBS_AWS]
+          filters: *filters
       - orb-tools/pack:
           filters: *filters
       - orb-tools/publish:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -359,194 +359,194 @@ workflows:
   test-deploy:
     jobs:
       # Make sure to include "filters: *filters" in every test job you want to run as part of your deployment.
-      - integration-test-ecs-cli-install:
-          version: "v1.9.0"
-          matrix:
-            parameters:
-              executor: [linux, mac]
-          filters: *filters
+      # - integration-test-ecs-cli-install:
+      #     version: "v1.9.0"
+      #     matrix:
+      #       parameters:
+      #         executor: [linux, mac]
+      #     filters: *filters
       #################
       # Fargate
       #################
-      - build-test-app:
-          name: fargate_build-test-app
-          docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
-          docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}:${CIRCLE_SHA1}"
-          context: [CPE_ORBS_AWS]
-          filters: *filters
-      - set-up-test-env:
-          name: fargate_set-up-test-env
-          filters: *filters
-          requires:
-            - fargate_build-test-app
-          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
-          terraform-config-dir: "tests/terraform_setup/fargate"
-          context: [CPE_ORBS_AWS]
-      - test-service-update:
-          name: fargate_test-update-service-command
-          filters: *filters
-          requires:
-            - fargate_set-up-test-env
-          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
-          family-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
-          service-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
-          docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
-          docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}:${CIRCLE_SHA1}"
-          context: [CPE_ORBS_AWS]
-      - aws-ecs/deploy-service-update:
-          name: fargate_test-update-service-job
-          docker-image-for-job: cimg/python:3.10.4
-          filters: *filters
-          requires:
-            - fargate_test-update-service-command
-          aws-access-key-id: AWS_ACCESS_KEY_ID
-          aws-region: AWS_DEFAULT_REGION
-          profile-name: "ECS_TEST_PROFILE"
-          family: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
-          cluster: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
-          container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service,name=BUILD_DATE,value=$(date)'
-          # test the force-new-deployment flag
-          force-new-deployment: true
-          verify-revision-is-deployed: true
-          max-poll-attempts: 40
-          poll-interval: 10
-          context: [CPE_ORBS_AWS]
-          post-steps:
-            - test-deployment:
-                service-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
-                cluster: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
-      - aws-ecs/deploy-service-update:
-          name: fargate_test-update-service-skip-registration
-          docker-image-for-job: cimg/python:3.10.4
-          filters: *filters
-          requires:
-            - fargate_test-update-service-job
-          aws-access-key-id: AWS_ACCESS_KEY_ID
-          aws-region: AWS_DEFAULT_REGION
-          profile-name: "ECS_TEST_PROFILE"
-          family: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
-          cluster: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
-          # test skipping registration of a new task definition
-          skip-task-definition-registration: true
-          # test the enable-circuit-breaker flag
-          enable-circuit-breaker: true
-          verify-revision-is-deployed: true
-          max-poll-attempts: 40
-          poll-interval: 10
-          context: [CPE_ORBS_AWS]
-      - tear-down-test-env:
-          name: fargate_tear-down-test-env
-          filters: *filters
-          requires:
-            - fargate_test-update-service-skip-registration
-            - test-fargatespot
-          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
-          terraform-config-dir: "tests/terraform_setup/fargate"
-          context: [CPE_ORBS_AWS]
+      # - build-test-app:
+      #     name: fargate_build-test-app
+      #     docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+      #     docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}:${CIRCLE_SHA1}"
+      #     context: [CPE_ORBS_AWS]
+      #     filters: *filters
+      # - set-up-test-env:
+      #     name: fargate_set-up-test-env
+      #     filters: *filters
+      #     requires:
+      #       - fargate_build-test-app
+      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
+      #     terraform-config-dir: "tests/terraform_setup/fargate"
+      #     context: [CPE_ORBS_AWS]
+      # - test-service-update:
+      #     name: fargate_test-update-service-command
+      #     filters: *filters
+      #     requires:
+      #       - fargate_set-up-test-env
+      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
+      #     family-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
+      #     service-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
+      #     docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+      #     docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}:${CIRCLE_SHA1}"
+      #     context: [CPE_ORBS_AWS]
+      # - aws-ecs/deploy-service-update:
+      #     name: fargate_test-update-service-job
+      #     docker-image-for-job: cimg/python:3.10.4
+      #     filters: *filters
+      #     requires:
+      #       - fargate_test-update-service-command
+      #     aws-access-key-id: AWS_ACCESS_KEY_ID
+      #     aws-region: AWS_DEFAULT_REGION
+      #     profile-name: "ECS_TEST_PROFILE"
+      #     family: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
+      #     cluster: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
+      #     container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service,name=BUILD_DATE,value=$(date)'
+      #     # test the force-new-deployment flag
+      #     force-new-deployment: true
+      #     verify-revision-is-deployed: true
+      #     max-poll-attempts: 40
+      #     poll-interval: 10
+      #     context: [CPE_ORBS_AWS]
+      #     post-steps:
+      #       - test-deployment:
+      #           service-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
+      #           cluster: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
+      # - aws-ecs/deploy-service-update:
+      #     name: fargate_test-update-service-skip-registration
+      #     docker-image-for-job: cimg/python:3.10.4
+      #     filters: *filters
+      #     requires:
+      #       - fargate_test-update-service-job
+      #     aws-access-key-id: AWS_ACCESS_KEY_ID
+      #     aws-region: AWS_DEFAULT_REGION
+      #     profile-name: "ECS_TEST_PROFILE"
+      #     family: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
+      #     cluster: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
+      #     # test skipping registration of a new task definition
+      #     skip-task-definition-registration: true
+      #     # test the enable-circuit-breaker flag
+      #     enable-circuit-breaker: true
+      #     verify-revision-is-deployed: true
+      #     max-poll-attempts: 40
+      #     poll-interval: 10
+      #     context: [CPE_ORBS_AWS]
+      # - tear-down-test-env:
+      #     name: fargate_tear-down-test-env
+      #     filters: *filters
+      #     requires:
+      #       - fargate_test-update-service-skip-registration
+      #       - test-fargatespot
+      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
+      #     terraform-config-dir: "tests/terraform_setup/fargate"
+      #     context: [CPE_ORBS_AWS]
 
       #################
       # EC2
       #################
-      - build-test-app:
-          name: ec2_build-test-app
-          docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
-          docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}:${CIRCLE_SHA1}"
-          context: [CPE_ORBS_AWS]
-          filters: *filters
-      - set-up-test-env:
-          name: ec2_set-up-test-env
-          filters: *filters
-          requires:
-            - ec2_build-test-app
-          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
-          terraform-config-dir: "tests/terraform_setup/ec2"
-          context: [CPE_ORBS_AWS]
-      - set-up-run-task-test:
-          name: ec2_set-up-run-task-test
-          filters: *filters
-          requires:
-            - ec2_set-up-test-env
-          family-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360"
-          context: [CPE_ORBS_AWS]
-      - aws-ecs/run-task:
-          name: ec2_run-task-test
-          filters: *filters
-          requires:
-            - ec2_set-up-run-task-test
-          cluster: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
-          aws-region: AWS_DEFAULT_REGION
-          task-definition: "${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360"
-          launch-type: "EC2"
-          awsvpc: false
-          run-task-output: "run-task-output.json"
-          overrides: '{"containerOverrides":[{"name": "${INTERPOLATION_TEST}", "memory": 512}]}'
-          context: [CPE_ORBS_AWS]
-      - tear-down-run-task-test:
-          name: ec2_tear-down-run-task-test
-          filters: *filters
-          requires:
-            - ec2_run-task-test
-          family-name: ${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360
-          context: [CPE_ORBS_AWS]
+      # - build-test-app:
+      #     name: ec2_build-test-app
+      #     docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+      #     docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}:${CIRCLE_SHA1}"
+      #     context: [CPE_ORBS_AWS]
+      #     filters: *filters
+      # - set-up-test-env:
+      #     name: ec2_set-up-test-env
+      #     filters: *filters
+      #     requires:
+      #       - ec2_build-test-app
+      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
+      #     terraform-config-dir: "tests/terraform_setup/ec2"
+      #     context: [CPE_ORBS_AWS]
+      # - set-up-run-task-test:
+      #     name: ec2_set-up-run-task-test
+      #     filters: *filters
+      #     requires:
+      #       - ec2_set-up-test-env
+      #     family-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360"
+      #     context: [CPE_ORBS_AWS]
+      # - aws-ecs/run-task:
+      #     name: ec2_run-task-test
+      #     filters: *filters
+      #     requires:
+      #       - ec2_set-up-run-task-test
+      #     cluster: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
+      #     aws-region: AWS_DEFAULT_REGION
+      #     task-definition: "${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360"
+      #     launch-type: "EC2"
+      #     awsvpc: false
+      #     run-task-output: "run-task-output.json"
+      #     overrides: '{"containerOverrides":[{"name": "${INTERPOLATION_TEST}", "memory": 512}]}'
+      #     context: [CPE_ORBS_AWS]
+      # - tear-down-run-task-test:
+      #     name: ec2_tear-down-run-task-test
+      #     filters: *filters
+      #     requires:
+      #       - ec2_run-task-test
+      #     family-name: ${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360
+      #     context: [CPE_ORBS_AWS]
 
-      - test-service-update:
-          name: ec2_test-update-service-command
-          filters: *filters
-          requires:
-            - ec2_set-up-test-env
-          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
-          family-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
-          service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
-          docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
-          docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}:${CIRCLE_SHA1}"
-          context: [CPE_ORBS_AWS]
-      - test-task-definition-update:
-          name: ec2_test-task-definition-update
-          family-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
-          context: [CPE_ORBS_AWS]
-          filters: *filters
-          requires:
-            - ec2_test-update-service-command
-      - aws-ecs/deploy-service-update:
-          name: ec2_test-update-service-job
-          docker-image-for-job: cimg/python:3.10.4
-          context: [CPE_ORBS_AWS]
-          filters: *filters
-          requires:
-            - ec2_test-task-definition-update
-          aws-access-key-id: AWS_ACCESS_KEY_ID
-          aws-region: AWS_DEFAULT_REGION
-          family: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
-          service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
-          cluster: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
-          container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_EC2}-service,name=VERSION_INFO,value="Asterisk * expansion test ${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_EC2}-service,name=BUILD_DATE,value=$(date)'
-          verify-revision-is-deployed: true
-          fail-on-verification-timeout: false
-          post-steps:
-            - test-deployment:
-                service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
-                cluster: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
-                test-asterisk-expansion: true
+      # - test-service-update:
+      #     name: ec2_test-update-service-command
+      #     filters: *filters
+      #     requires:
+      #       - ec2_set-up-test-env
+      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
+      #     family-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
+      #     service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
+      #     docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+      #     docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}:${CIRCLE_SHA1}"
+      #     context: [CPE_ORBS_AWS]
+      # - test-task-definition-update:
+      #     name: ec2_test-task-definition-update
+      #     family-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
+      #     context: [CPE_ORBS_AWS]
+      #     filters: *filters
+      #     requires:
+      #       - ec2_test-update-service-command
+      # - aws-ecs/deploy-service-update:
+      #     name: ec2_test-update-service-job
+      #     docker-image-for-job: cimg/python:3.10.4
+      #     context: [CPE_ORBS_AWS]
+      #     filters: *filters
+      #     requires:
+      #       - ec2_test-task-definition-update
+      #     aws-access-key-id: AWS_ACCESS_KEY_ID
+      #     aws-region: AWS_DEFAULT_REGION
+      #     family: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
+      #     service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
+      #     cluster: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
+      #     container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_EC2}-service,name=VERSION_INFO,value="Asterisk * expansion test ${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_EC2}-service,name=BUILD_DATE,value=$(date)'
+      #     verify-revision-is-deployed: true
+      #     fail-on-verification-timeout: false
+      #     post-steps:
+      #       - test-deployment:
+      #           service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
+      #           cluster: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
+      #           test-asterisk-expansion: true
 
-      - tear-down-test-env:
-          name: ec2_tear-down-test-env
-          filters: *filters
-          requires:
-            - ec2_test-update-service-job
-            - ec2_tear-down-run-task-test
-          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
-          terraform-config-dir: "tests/terraform_setup/ec2"
-          context: [CPE_ORBS_AWS]
+      # - tear-down-test-env:
+      #     name: ec2_tear-down-test-env
+      #     filters: *filters
+      #     requires:
+      #       - ec2_test-update-service-job
+      #       - ec2_tear-down-run-task-test
+      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
+      #     terraform-config-dir: "tests/terraform_setup/ec2"
+      #     context: [CPE_ORBS_AWS]
 
       # #################
       # # FargateSpot
       # #################
 
-      - test-fargatespot:
-          context: [CPE_ORBS_AWS]
-          filters: *filters
-          requires:
-            - fargate_set-up-test-env
+      # - test-fargatespot:
+      #     context: [CPE_ORBS_AWS]
+      #     filters: *filters
+      #     requires:
+      #       - fargate_set-up-test-env
 
       #################
       # CodeDeploy
@@ -605,43 +605,43 @@ workflows:
                 service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
                 cluster: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
                 delete-load-balancer: false
-      - aws-ecs/deploy-service-update:
-          name: codedeploy_fargate_test-update-and-wait-service-job
-          docker-image-for-job: cimg/python:3.10.4
-          context: [CPE_ORBS_AWS]
-          filters: *filters
-          requires:
-            - codedeploy_fargate_test-update-service-job
-          aws-access-key-id: AWS_ACCESS_KEY_ID
-          aws-region: AWS_DEFAULT_REGION
-          family: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-          cluster: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
-          container-image-name-updates: "container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,image-and-tag=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
-          container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=BUILD_DATE,value=$(date)'
-          deployment-controller: "CODE_DEPLOY"
-          codedeploy-application-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeployapp"
-          codedeploy-deployment-group-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
-          codedeploy-load-balanced-container-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-          codedeploy-load-balanced-container-port: 8080
-          verify-revision-is-deployed: true
-          verification-timeout: "12m"
-          post-steps:
-            - test-deployment:
-                service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-                cluster: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
-                delete-load-balancer: true
-            - delete-service:
-                service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-                cluster: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
-      - tear-down-test-env:
-          name: codedeploy_fargate_tear-down-test-env
-          requires:
-            - codedeploy_fargate_test-update-and-wait-service-job
-          terraform-image: "hashicorp/terraform:1.1.9"
-          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
-          terraform-config-dir: "tests/terraform_setup/fargate_codedeploy"
-          context: [CPE_ORBS_AWS]
-          filters: *filters
+      # - aws-ecs/deploy-service-update:
+      #     name: codedeploy_fargate_test-update-and-wait-service-job
+      #     docker-image-for-job: cimg/python:3.10.4
+      #     context: [CPE_ORBS_AWS]
+      #     filters: *filters
+      #     requires:
+      #       - codedeploy_fargate_test-update-service-job
+      #     aws-access-key-id: AWS_ACCESS_KEY_ID
+      #     aws-region: AWS_DEFAULT_REGION
+      #     family: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+      #     cluster: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+      #     container-image-name-updates: "container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,image-and-tag=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
+      #     container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=BUILD_DATE,value=$(date)'
+      #     deployment-controller: "CODE_DEPLOY"
+      #     codedeploy-application-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeployapp"
+      #     codedeploy-deployment-group-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
+      #     codedeploy-load-balanced-container-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+      #     codedeploy-load-balanced-container-port: 8080
+      #     verify-revision-is-deployed: true
+      #     verification-timeout: "12m"
+      #     post-steps:
+      #       - test-deployment:
+      #           service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+      #           cluster: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+      #           delete-load-balancer: true
+      #       - delete-service:
+      #           service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+      #           cluster: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+      # - tear-down-test-env:
+      #     name: codedeploy_fargate_tear-down-test-env
+      #     requires:
+      #       - codedeploy_fargate_test-update-and-wait-service-job
+      #     terraform-image: "hashicorp/terraform:1.1.9"
+      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
+      #     terraform-config-dir: "tests/terraform_setup/fargate_codedeploy"
+      #     context: [CPE_ORBS_AWS]
+      #     filters: *filters
       - orb-tools/pack:
           filters: *filters
       - orb-tools/publish:
@@ -649,11 +649,11 @@ workflows:
           vcs-type: << pipeline.project.type >>
           pub-type: production
           requires:
-            - orb-tools/pack
-            - ec2_tear-down-test-env
-            - fargate_tear-down-test-env  
-            - codedeploy_fargate_tear-down-test-env
-            - integration-test-ecs-cli-install
+            # - orb-tools/pack
+            # - ec2_tear-down-test-env
+            # - fargate_tear-down-test-env  
+            # - codedeploy_fargate_tear-down-test-env
+            # - integration-test-ecs-cli-install
           context: orb-publisher
           filters:
             branches:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -597,7 +597,7 @@ workflows:
           codedeploy-load-balanced-container-port: 8080
           codedeploy-capacity-provider-name: "FARGATE"
           codedeploy-capacity-provider-base: "1"
-          codedeploy-capacity-provider-weight: "0"
+          codedeploy-capacity-provider-weight: "2"
           verify-revision-is-deployed: false
           context: [CPE_ORBS_AWS]
           post-steps:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -359,194 +359,194 @@ workflows:
   test-deploy:
     jobs:
       # Make sure to include "filters: *filters" in every test job you want to run as part of your deployment.
-      # - integration-test-ecs-cli-install:
-      #     version: "v1.9.0"
-      #     matrix:
-      #       parameters:
-      #         executor: [linux, mac]
-      #     filters: *filters
+      - integration-test-ecs-cli-install:
+          version: "v1.9.0"
+          matrix:
+            parameters:
+              executor: [linux, mac]
+          filters: *filters
       #################
       # Fargate
       #################
-      # - build-test-app:
-      #     name: fargate_build-test-app
-      #     docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
-      #     docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}:${CIRCLE_SHA1}"
-      #     context: [CPE_ORBS_AWS]
-      #     filters: *filters
-      # - set-up-test-env:
-      #     name: fargate_set-up-test-env
-      #     filters: *filters
-      #     requires:
-      #       - fargate_build-test-app
-      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
-      #     terraform-config-dir: "tests/terraform_setup/fargate"
-      #     context: [CPE_ORBS_AWS]
-      # - test-service-update:
-      #     name: fargate_test-update-service-command
-      #     filters: *filters
-      #     requires:
-      #       - fargate_set-up-test-env
-      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
-      #     family-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
-      #     service-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
-      #     docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
-      #     docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}:${CIRCLE_SHA1}"
-      #     context: [CPE_ORBS_AWS]
-      # - aws-ecs/deploy-service-update:
-      #     name: fargate_test-update-service-job
-      #     docker-image-for-job: cimg/python:3.10.4
-      #     filters: *filters
-      #     requires:
-      #       - fargate_test-update-service-command
-      #     aws-access-key-id: AWS_ACCESS_KEY_ID
-      #     aws-region: AWS_DEFAULT_REGION
-      #     profile-name: "ECS_TEST_PROFILE"
-      #     family: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
-      #     cluster: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
-      #     container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service,name=BUILD_DATE,value=$(date)'
-      #     # test the force-new-deployment flag
-      #     force-new-deployment: true
-      #     verify-revision-is-deployed: true
-      #     max-poll-attempts: 40
-      #     poll-interval: 10
-      #     context: [CPE_ORBS_AWS]
-      #     post-steps:
-      #       - test-deployment:
-      #           service-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
-      #           cluster: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
-      # - aws-ecs/deploy-service-update:
-      #     name: fargate_test-update-service-skip-registration
-      #     docker-image-for-job: cimg/python:3.10.4
-      #     filters: *filters
-      #     requires:
-      #       - fargate_test-update-service-job
-      #     aws-access-key-id: AWS_ACCESS_KEY_ID
-      #     aws-region: AWS_DEFAULT_REGION
-      #     profile-name: "ECS_TEST_PROFILE"
-      #     family: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
-      #     cluster: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
-      #     # test skipping registration of a new task definition
-      #     skip-task-definition-registration: true
-      #     # test the enable-circuit-breaker flag
-      #     enable-circuit-breaker: true
-      #     verify-revision-is-deployed: true
-      #     max-poll-attempts: 40
-      #     poll-interval: 10
-      #     context: [CPE_ORBS_AWS]
-      # - tear-down-test-env:
-      #     name: fargate_tear-down-test-env
-      #     filters: *filters
-      #     requires:
-      #       - fargate_test-update-service-skip-registration
-      #       - test-fargatespot
-      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
-      #     terraform-config-dir: "tests/terraform_setup/fargate"
-      #     context: [CPE_ORBS_AWS]
+      - build-test-app:
+          name: fargate_build-test-app
+          docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+          docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}:${CIRCLE_SHA1}"
+          context: [CPE_ORBS_AWS]
+          filters: *filters
+      - set-up-test-env:
+          name: fargate_set-up-test-env
+          filters: *filters
+          requires:
+            - fargate_build-test-app
+          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
+          terraform-config-dir: "tests/terraform_setup/fargate"
+          context: [CPE_ORBS_AWS]
+      - test-service-update:
+          name: fargate_test-update-service-command
+          filters: *filters
+          requires:
+            - fargate_set-up-test-env
+          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
+          family-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
+          service-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
+          docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+          docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}:${CIRCLE_SHA1}"
+          context: [CPE_ORBS_AWS]
+      - aws-ecs/deploy-service-update:
+          name: fargate_test-update-service-job
+          docker-image-for-job: cimg/python:3.10.4
+          filters: *filters
+          requires:
+            - fargate_test-update-service-command
+          aws-access-key-id: AWS_ACCESS_KEY_ID
+          aws-region: AWS_DEFAULT_REGION
+          profile-name: "ECS_TEST_PROFILE"
+          family: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
+          cluster: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
+          container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service,name=BUILD_DATE,value=$(date)'
+          # test the force-new-deployment flag
+          force-new-deployment: true
+          verify-revision-is-deployed: true
+          max-poll-attempts: 40
+          poll-interval: 10
+          context: [CPE_ORBS_AWS]
+          post-steps:
+            - test-deployment:
+                service-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
+                cluster: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
+      - aws-ecs/deploy-service-update:
+          name: fargate_test-update-service-skip-registration
+          docker-image-for-job: cimg/python:3.10.4
+          filters: *filters
+          requires:
+            - fargate_test-update-service-job
+          aws-access-key-id: AWS_ACCESS_KEY_ID
+          aws-region: AWS_DEFAULT_REGION
+          profile-name: "ECS_TEST_PROFILE"
+          family: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
+          cluster: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
+          # test skipping registration of a new task definition
+          skip-task-definition-registration: true
+          # test the enable-circuit-breaker flag
+          enable-circuit-breaker: true
+          verify-revision-is-deployed: true
+          max-poll-attempts: 40
+          poll-interval: 10
+          context: [CPE_ORBS_AWS]
+      - tear-down-test-env:
+          name: fargate_tear-down-test-env
+          filters: *filters
+          requires:
+            - fargate_test-update-service-skip-registration
+            - test-fargatespot
+          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
+          terraform-config-dir: "tests/terraform_setup/fargate"
+          context: [CPE_ORBS_AWS]
 
       #################
       # EC2
       #################
-      # - build-test-app:
-      #     name: ec2_build-test-app
-      #     docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
-      #     docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}:${CIRCLE_SHA1}"
-      #     context: [CPE_ORBS_AWS]
-      #     filters: *filters
-      # - set-up-test-env:
-      #     name: ec2_set-up-test-env
-      #     filters: *filters
-      #     requires:
-      #       - ec2_build-test-app
-      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
-      #     terraform-config-dir: "tests/terraform_setup/ec2"
-      #     context: [CPE_ORBS_AWS]
-      # - set-up-run-task-test:
-      #     name: ec2_set-up-run-task-test
-      #     filters: *filters
-      #     requires:
-      #       - ec2_set-up-test-env
-      #     family-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360"
-      #     context: [CPE_ORBS_AWS]
-      # - aws-ecs/run-task:
-      #     name: ec2_run-task-test
-      #     filters: *filters
-      #     requires:
-      #       - ec2_set-up-run-task-test
-      #     cluster: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
-      #     aws-region: AWS_DEFAULT_REGION
-      #     task-definition: "${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360"
-      #     launch-type: "EC2"
-      #     awsvpc: false
-      #     run-task-output: "run-task-output.json"
-      #     overrides: '{"containerOverrides":[{"name": "${INTERPOLATION_TEST}", "memory": 512}]}'
-      #     context: [CPE_ORBS_AWS]
-      # - tear-down-run-task-test:
-      #     name: ec2_tear-down-run-task-test
-      #     filters: *filters
-      #     requires:
-      #       - ec2_run-task-test
-      #     family-name: ${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360
-      #     context: [CPE_ORBS_AWS]
+      - build-test-app:
+          name: ec2_build-test-app
+          docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+          docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}:${CIRCLE_SHA1}"
+          context: [CPE_ORBS_AWS]
+          filters: *filters
+      - set-up-test-env:
+          name: ec2_set-up-test-env
+          filters: *filters
+          requires:
+            - ec2_build-test-app
+          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
+          terraform-config-dir: "tests/terraform_setup/ec2"
+          context: [CPE_ORBS_AWS]
+      - set-up-run-task-test:
+          name: ec2_set-up-run-task-test
+          filters: *filters
+          requires:
+            - ec2_set-up-test-env
+          family-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360"
+          context: [CPE_ORBS_AWS]
+      - aws-ecs/run-task:
+          name: ec2_run-task-test
+          filters: *filters
+          requires:
+            - ec2_set-up-run-task-test
+          cluster: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
+          aws-region: AWS_DEFAULT_REGION
+          task-definition: "${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360"
+          launch-type: "EC2"
+          awsvpc: false
+          run-task-output: "run-task-output.json"
+          overrides: '{"containerOverrides":[{"name": "${INTERPOLATION_TEST}", "memory": 512}]}'
+          context: [CPE_ORBS_AWS]
+      - tear-down-run-task-test:
+          name: ec2_tear-down-run-task-test
+          filters: *filters
+          requires:
+            - ec2_run-task-test
+          family-name: ${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360
+          context: [CPE_ORBS_AWS]
 
-      # - test-service-update:
-      #     name: ec2_test-update-service-command
-      #     filters: *filters
-      #     requires:
-      #       - ec2_set-up-test-env
-      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
-      #     family-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
-      #     service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
-      #     docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
-      #     docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}:${CIRCLE_SHA1}"
-      #     context: [CPE_ORBS_AWS]
-      # - test-task-definition-update:
-      #     name: ec2_test-task-definition-update
-      #     family-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
-      #     context: [CPE_ORBS_AWS]
-      #     filters: *filters
-      #     requires:
-      #       - ec2_test-update-service-command
-      # - aws-ecs/deploy-service-update:
-      #     name: ec2_test-update-service-job
-      #     docker-image-for-job: cimg/python:3.10.4
-      #     context: [CPE_ORBS_AWS]
-      #     filters: *filters
-      #     requires:
-      #       - ec2_test-task-definition-update
-      #     aws-access-key-id: AWS_ACCESS_KEY_ID
-      #     aws-region: AWS_DEFAULT_REGION
-      #     family: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
-      #     service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
-      #     cluster: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
-      #     container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_EC2}-service,name=VERSION_INFO,value="Asterisk * expansion test ${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_EC2}-service,name=BUILD_DATE,value=$(date)'
-      #     verify-revision-is-deployed: true
-      #     fail-on-verification-timeout: false
-      #     post-steps:
-      #       - test-deployment:
-      #           service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
-      #           cluster: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
-      #           test-asterisk-expansion: true
+      - test-service-update:
+          name: ec2_test-update-service-command
+          filters: *filters
+          requires:
+            - ec2_set-up-test-env
+          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
+          family-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
+          service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
+          docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+          docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}:${CIRCLE_SHA1}"
+          context: [CPE_ORBS_AWS]
+      - test-task-definition-update:
+          name: ec2_test-task-definition-update
+          family-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
+          context: [CPE_ORBS_AWS]
+          filters: *filters
+          requires:
+            - ec2_test-update-service-command
+      - aws-ecs/deploy-service-update:
+          name: ec2_test-update-service-job
+          docker-image-for-job: cimg/python:3.10.4
+          context: [CPE_ORBS_AWS]
+          filters: *filters
+          requires:
+            - ec2_test-task-definition-update
+          aws-access-key-id: AWS_ACCESS_KEY_ID
+          aws-region: AWS_DEFAULT_REGION
+          family: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
+          service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
+          cluster: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
+          container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_EC2}-service,name=VERSION_INFO,value="Asterisk * expansion test ${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_EC2}-service,name=BUILD_DATE,value=$(date)'
+          verify-revision-is-deployed: true
+          fail-on-verification-timeout: false
+          post-steps:
+            - test-deployment:
+                service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
+                cluster: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
+                test-asterisk-expansion: true
 
-      # - tear-down-test-env:
-      #     name: ec2_tear-down-test-env
-      #     filters: *filters
-      #     requires:
-      #       - ec2_test-update-service-job
-      #       - ec2_tear-down-run-task-test
-      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
-      #     terraform-config-dir: "tests/terraform_setup/ec2"
-      #     context: [CPE_ORBS_AWS]
+      - tear-down-test-env:
+          name: ec2_tear-down-test-env
+          filters: *filters
+          requires:
+            - ec2_test-update-service-job
+            - ec2_tear-down-run-task-test
+          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
+          terraform-config-dir: "tests/terraform_setup/ec2"
+          context: [CPE_ORBS_AWS]
 
       # #################
       # # FargateSpot
       # #################
 
-      # - test-fargatespot:
-      #     context: [CPE_ORBS_AWS]
-      #     filters: *filters
-      #     requires:
-      #       - fargate_set-up-test-env
+      - test-fargatespot:
+          context: [CPE_ORBS_AWS]
+          filters: *filters
+          requires:
+            - fargate_set-up-test-env
 
       #################
       # CodeDeploy
@@ -608,40 +608,38 @@ workflows:
                 service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
                 cluster: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
                 delete-load-balancer: false
-      # - aws-ecs/deploy-service-update:
-      #     name: codedeploy_fargate_test-update-and-wait-service-job
-      #     docker-image-for-job: cimg/python:3.10.4
-      #     context: [CPE_ORBS_AWS]
-      #     filters: *filters
-      #     requires:
-      #       - codedeploy_fargate_test-update-service-job
-      #     aws-access-key-id: AWS_ACCESS_KEY_ID
-      #     aws-region: AWS_DEFAULT_REGION
-      #     family: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-      #     cluster: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
-      #     container-image-name-updates: "container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,image-and-tag=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
-      #     container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=BUILD_DATE,value=$(date)'
-      #     deployment-controller: "CODE_DEPLOY"
-      #     codedeploy-application-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeployapp"
-      #     codedeploy-deployment-group-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
-      #     codedeploy-load-balanced-container-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-      #     codedeploy-load-balanced-container-port: 8080
-      #     verify-revision-is-deployed: true
-      #     verification-timeout: "12m"
-      #     post-steps:
-      #       - test-deployment:
-      #           service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-      #           cluster: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
-      #           delete-load-balancer: true
-      #       - delete-service:
-      #           service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-      #           cluster: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
-      - tear-down-test-env:
-          name: codedeploy_fargate_tear-down-test-env
-          # requires:
-          #   - codedeploy_fargate_test-update-and-wait-service-job
+      - aws-ecs/deploy-service-update:
+          name: codedeploy_fargate_test-update-and-wait-service-job
+          docker-image-for-job: cimg/python:3.10.4
+          context: [CPE_ORBS_AWS]
+          filters: *filters
           requires:
             - codedeploy_fargate_test-update-service-job
+          aws-access-key-id: AWS_ACCESS_KEY_ID
+          aws-region: AWS_DEFAULT_REGION
+          family: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+          cluster: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+          container-image-name-updates: "container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,image-and-tag=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
+          container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=BUILD_DATE,value=$(date)'
+          deployment-controller: "CODE_DEPLOY"
+          codedeploy-application-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeployapp"
+          codedeploy-deployment-group-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
+          codedeploy-load-balanced-container-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+          codedeploy-load-balanced-container-port: 8080
+          verify-revision-is-deployed: true
+          verification-timeout: "12m"
+          post-steps:
+            - test-deployment:
+                service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+                cluster: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+                delete-load-balancer: true
+            - delete-service:
+                service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+                cluster: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+      - tear-down-test-env:
+          name: codedeploy_fargate_tear-down-test-env
+          requires:
+            - codedeploy_fargate_test-update-and-wait-service-job
           terraform-image: "hashicorp/terraform:1.1.9"
           aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
           terraform-config-dir: "tests/terraform_setup/fargate_codedeploy"
@@ -654,11 +652,11 @@ workflows:
           vcs-type: << pipeline.project.type >>
           pub-type: production
           requires:
-            # - orb-tools/pack
-            # - ec2_tear-down-test-env
-            # - fargate_tear-down-test-env  
-            # - codedeploy_fargate_tear-down-test-env
-            # - integration-test-ecs-cli-install
+            - orb-tools/pack
+            - ec2_tear-down-test-env
+            - fargate_tear-down-test-env  
+            - codedeploy_fargate_tear-down-test-env
+            - integration-test-ecs-cli-install
           context: orb-publisher
           filters:
             branches:

--- a/src/commands/run-task.yml
+++ b/src/commands/run-task.yml
@@ -140,6 +140,6 @@ steps:
         ECS_PARAM_TAGS: <<parameters.tags>>
         ECS_PARAM_ENABLE_ECS_MANAGED_TAGS: <<parameters.enable-ecs-managed-tags>>
         ECS_PARAM_PROPAGATE_TAGS: <<parameters.propagate-tags>>
-        ECS_PARAM_CAPACITY_PROVIDER_STRATEGY: <<parameters.capacity-provider-strategy>>
+        ECS_PARAM_CD_CAPACITY_PROVIDER_STRATEGY: <<parameters.capacity-provider-strategy>>
         ECS_PARAM_PROFILE_NAME: <<parameters.profile-name>>
         ECS_PARAM_RUN_TASK_OUTPUT: <<parameters.run-task-output>>

--- a/src/commands/update-service.yml
+++ b/src/commands/update-service.yml
@@ -138,22 +138,22 @@ parameters:
     description: AWS profile name to be configured.
     type: string
     default: ''
-  capacity-provider-name:
+  codedeploy-capacity-provider-name:
     description: >
       The name of AWS Capacity Provider to be added to CodeDeploy deployment.
       Must be used with capacity-provider-base and capacity-provider-weight.
     type: string
     default: ''
-  capacity-provider-base:
+  codedeploy-capacity-provider-base:
     description: >
       The base of AWS Capacity Provider to be added to CodeDeploy deployment.
-      Must be used with capacity-provider-name and capacity-provider-weight.
+      Must be used with codedeploy-capacity-provider-name and codedeploy-capacity-provider-weight.
     type: string
     default: ''
-  capacity-provider-weight:
+  codedeploy-capacity-provider-weight:
     description: >
       The base of AWS Capacity Provider to be added to CodeDeploy deployment.
-      Must be used with capacity-provider-name and capacity-provider-base.
+      Must be used with codedeploy-capacity-provider-name and codedeploy-capacity-provider-base.
     type: string
     default: ''
 
@@ -206,9 +206,9 @@ steps:
               ECS_PARAM_VERIFY_REV_DEPLOY: <<parameters.verify-revision-is-deployed>>
               ECS_PARAM_PROFILE_NAME: <<parameters.profile-name>>
               ECS_PARAM_ENABLE_CIRCUIT_BREAKER: <<parameters.enable-circuit-breaker>>
-              ECS_PARAM_CAPACITY_PROVIDER_NAME: <<parameters.capacity-provider-name>>
-              ECS_PARAM_CAPACITY_PROVIDER_WEIGHT: <<parameters.capacity-provider-weight>>
-              ECS_PARAM_CAPACITY_PROVIDER_BASE: <<parameters.capacity-provider-base>>
+              ECS_PARAM_CD_CAPACITY_PROVIDER_NAME: <<parameters.codedeploy-capacity-provider-name>>
+              ECS_PARAM_CD_CAPACITY_PROVIDER_WEIGHT: <<parameters.codedeploy-capacity-provider-weight>>
+              ECS_PARAM_CD_CAPACITY_PROVIDER_BASE: <<parameters.codedeploy-capacity-provider-base>>
 
   - when:
       condition:

--- a/src/commands/update-service.yml
+++ b/src/commands/update-service.yml
@@ -152,7 +152,7 @@ parameters:
     default: ''
   codedeploy-capacity-provider-weight:
     description: >
-      The base of AWS Capacity Provider to be added to CodeDeploy deployment.
+      The weight of AWS Capacity Provider to be added to CodeDeploy deployment. Weight must be greater than 0.
       Must be used with codedeploy-capacity-provider-name and codedeploy-capacity-provider-base.
     type: string
     default: ''

--- a/src/commands/update-service.yml
+++ b/src/commands/update-service.yml
@@ -138,6 +138,24 @@ parameters:
     description: AWS profile name to be configured.
     type: string
     default: ''
+  capacity-provider-name:
+    description: >
+      The name of AWS Capacity Provider to be added to CodeDeploy deployment.
+      Must be used with capacity-provider-base and capacity-provider-weight.
+    type: string
+    default: ''
+  capacity-provider-base:
+    description: >
+      The base of AWS Capacity Provider to be added to CodeDeploy deployment.
+      Must be used with capacity-provider-name and capacity-provider-weight.
+    type: string
+    default: ''
+  capacity-provider-weight:
+    description: >
+      The base of AWS Capacity Provider to be added to CodeDeploy deployment.
+      Must be used with capacity-provider-name and capacity-provider-base.
+    type: string
+    default: ''
 
 steps:
   - unless:
@@ -188,6 +206,10 @@ steps:
               ECS_PARAM_VERIFY_REV_DEPLOY: <<parameters.verify-revision-is-deployed>>
               ECS_PARAM_PROFILE_NAME: <<parameters.profile-name>>
               ECS_PARAM_ENABLE_CIRCUIT_BREAKER: <<parameters.enable-circuit-breaker>>
+              ECS_PARAM_CAPACITY_PROVIDER_NAME: <<parameters.capacity-provider-name>>
+              ECS_PARAM_CAPACITY_PROVIDER_WEIGHT: <<parameters.capacity-provider-weight>>
+              ECS_PARAM_CAPACITY_PROVIDER_BASE: <<parameters.capacity-provider-base>>
+
   - when:
       condition:
         equal:

--- a/src/jobs/deploy-service-update.yml
+++ b/src/jobs/deploy-service-update.yml
@@ -185,6 +185,24 @@ parameters:
       Values should not contain commas.
     type: string
     default: ''
+  capacity-provider-name:
+    description: >
+      The name of AWS Capacity Provider to be added to CodeDeploy deployment.
+      Must be used with capacity-provider-base and capacity-provider-weight.
+    type: string
+    default: ''
+  capacity-provider-base:
+    description: >
+      The base of AWS Capacity Provider to be added to CodeDeploy deployment.
+      Must be used with capacity-provider-name and capacity-provider-weight.
+    type: string
+    default: ''
+  capacity-provider-weight:
+    description: >
+      The base of AWS Capacity Provider to be added to CodeDeploy deployment.
+      Must be used with capacity-provider-name and capacity-provider-base.
+    type: string
+    default: ''
 steps:
   - aws-cli/setup:
       aws-access-key-id: << parameters.aws-access-key-id >>
@@ -212,3 +230,6 @@ steps:
       task-definition-tags: << parameters.task-definition-tags >>
       verification-timeout: << parameters.verification-timeout >>
       profile-name: << parameters.profile-name >>
+      capacity-provider-name: <<parameters.capacity-provider-name>>
+      capacity-provider-weight: <<parameters.capacity-provider-weight>>
+      capacity-provider-base: <<parameters.capacity-provider-base>>

--- a/src/jobs/deploy-service-update.yml
+++ b/src/jobs/deploy-service-update.yml
@@ -185,22 +185,22 @@ parameters:
       Values should not contain commas.
     type: string
     default: ''
-  capacity-provider-name:
+  codedeploy-capacity-provider-name:
     description: >
       The name of AWS Capacity Provider to be added to CodeDeploy deployment.
       Must be used with capacity-provider-base and capacity-provider-weight.
     type: string
     default: ''
-  capacity-provider-base:
+  codedeploy-capacity-provider-base:
     description: >
       The base of AWS Capacity Provider to be added to CodeDeploy deployment.
-      Must be used with capacity-provider-name and capacity-provider-weight.
+      Must be used with codedeploy-capacity-provider-name and capacity-provider-weight.
     type: string
     default: ''
-  capacity-provider-weight:
+  codedeploy-capacity-provider-weight:
     description: >
       The base of AWS Capacity Provider to be added to CodeDeploy deployment.
-      Must be used with capacity-provider-name and capacity-provider-base.
+      Must be used with codedeploy-capacity-provider-name and capacity-provider-base.
     type: string
     default: ''
 steps:
@@ -230,6 +230,6 @@ steps:
       task-definition-tags: << parameters.task-definition-tags >>
       verification-timeout: << parameters.verification-timeout >>
       profile-name: << parameters.profile-name >>
-      capacity-provider-name: <<parameters.capacity-provider-name>>
-      capacity-provider-weight: <<parameters.capacity-provider-weight>>
-      capacity-provider-base: <<parameters.capacity-provider-base>>
+      codedeploy-capacity-provider-name: <<parameters.codedeploy-capacity-provider-name>>
+      codedeploy-capacity-provider-weight: <<parameters.codedeploy-capacity-provider-weight>>
+      codedeploy-capacity-provider-base: <<parameters.codedeploy-capacity-provider-base>>

--- a/src/scripts/run-task.sh
+++ b/src/scripts/run-task.sh
@@ -60,15 +60,15 @@ if [ "$ECS_PARAM_AWSVPC" == "1" ]; then
     ECS_PARAM_SEC_GROUP_ID=$(eval echo "$ECS_PARAM_SEC_GROUP_ID")
     set -- "$@" --network-configuration awsvpcConfiguration="{subnets=[$ECS_PARAM_SUBNET_ID],securityGroups=[$ECS_PARAM_SEC_GROUP_ID],assignPublicIp=$ECS_PARAM_ASSIGN_PUB_IP}"
 fi
-if [ -n "$ECS_PARAM_CAPACITY_PROVIDER_STRATEGY" ]; then
+if [ -n "$ECS_PARAM_CD_CAPACITY_PROVIDER_STRATEGY" ]; then
     echo "Setting --capacity-provider-strategy"
     # do not quote
     # shellcheck disable=SC2086
-    set -- "$@" --capacity-provider-strategy $ECS_PARAM_CAPACITY_PROVIDER_STRATEGY
+    set -- "$@" --capacity-provider-strategy $ECS_PARAM_CD_CAPACITY_PROVIDER_STRATEGY
 fi
 
 if [ -n "$ECS_PARAM_LAUNCH_TYPE" ]; then
-    if [ -n "$ECS_PARAM_CAPACITY_PROVIDER_STRATEGY" ]; then
+    if [ -n "$ECS_PARAM_CD_CAPACITY_PROVIDER_STRATEGY" ]; then
         echo "Error: "
         echo 'If a "capacity-provider-strategy" is specified, the "launch-type" parameter must be set to an empty string.'
         exit 1

--- a/src/scripts/update-bluegreen-service-via-task-def.sh
+++ b/src/scripts/update-bluegreen-service-via-task-def.sh
@@ -23,15 +23,6 @@ else
     REVISION="{\"revisionType\": \"AppSpecContent\", \"appSpecContent\": {\"content\": \"{\\\"version\\\": 1, \\\"Resources\\\": [{\\\"TargetService\\\": {\\\"Type\\\": \\\"AWS::ECS::Service\\\", \\\"Properties\\\": {\\\"TaskDefinition\\\": \\\"${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN}\\\", \\\"LoadBalancerInfo\\\": {\\\"ContainerName\\\": \\\"$ECS_PARAM_CD_LOAD_BALANCED_CONTAINER_NAME\\\", \\\"ContainerPort\\\": $ECS_PARAM_CD_LOAD_BALANCED_CONTAINER_PORT}}}}]}\"}}"
 fi 
 
-# REVISION="{\"revisionType\": \"AppSpecContent\", \"appSpecContent\": {\"content\": \"{\\\"version\\\": 1, \\\"Resources\\\": [{\\\"TargetService\\\": {\\\"Type\\\": \\\"AWS::ECS::Service\\\", \\\"Properties\\\": {\\\"TaskDefinition\\\": \\\"${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN}\\\", \\\"LoadBalancerInfo\\\": {\\\"ContainerName\\\": \\\"$ECS_PARAM_CD_LOAD_BALANCED_CONTAINER_NAME\\\", \\\"ContainerPort\\\": $ECS_PARAM_CD_LOAD_BALANCED_CONTAINER_PORT}}}}]}\"}}"
-#shellcheck disable=SC2086
-# APPSPEC=$(echo '{"version":1,"Resources":[{"TargetService":{"Type":"AWS::ECS::Service","Properties":{"TaskDefinition":"'${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN}'","LoadBalancerInfo":{"ContainerName":"'${ECS_PARAM_CD_LOAD_BALANCED_CONTAINER_NAME}'","ContainerPort":"'${ECS_PARAM_CD_LOAD_BALANCED_CONTAINER_PORT}'"},"CapacityProviderStrategy":[{"CapacityProvider":"FARGATE", "Base":0, "Weight":1}]}}}}]}' | jq -Rs .)
-# REVISION='{"revisionType":"AppSpecContent","appSpecContent":{"content":'${APPSPEC}'}}'
-    # --revision "$REVISION" \
-    # --revision "{\"revisionType\": \"AppSpecContent\", \"appSpecContent\": {\"content\": \"{\\\"version\\\": 1, \\\"Resources\\\": [{\\\"TargetService\\\": {\\\"Type\\\": \\\"AWS::ECS::Service\\\", \\\"Properties\\\": {\\\"TaskDefinition\\\": \\\"${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN}\\\", \\\"LoadBalancerInfo\\\": {\\\"ContainerName\\\": \\\"$ECS_PARAM_CD_LOAD_BALANCED_CONTAINER_NAME\\\", \\\"ContainerPort\\\": $ECS_PARAM_CD_LOAD_BALANCED_CONTAINER_PORT}}}}]}\"}}" \
-
-    # --revision "{\"revisionType\": \"AppSpecContent\", \"appSpecContent\": {\"content\": \"{\\\"version\\\": 1, \\\"Resources\\\": [{\\\"TargetService\\\": {\\\"Type\\\": \\\"AWS::ECS::Service\\\", \\\"Properties\\\": {\\\"TaskDefinition\\\": \\\"${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN}\\\", \\\"LoadBalancerInfo\\\": {\\\"ContainerName\\\": \\\"$ECS_PARAM_CD_LOAD_BALANCED_CONTAINER_NAME\\\", \\\"ContainerPort\\\": $ECS_PARAM_CD_LOAD_BALANCED_CONTAINER_PORT},\\\"CapacityProviderStrategy\\\":[{\\\"CapacityProvider\\\":\\\"FARGATE\\\", \\\"Base\\\":3, \\\"Weight\\\":1}]}}}]}\"}}" \
-
 DEPLOYMENT_ID=$(aws deploy create-deployment \
     --application-name "$ECS_PARAM_CD_APP_NAME" \
     --deployment-group-name "$ECS_PARAM_CD_DEPLOY_GROUP_NAME" \
@@ -42,7 +33,7 @@ echo "Created CodeDeploy deployment: $DEPLOYMENT_ID"
 
 if [ "$ECS_PARAM_VERIFY_REV_DEPLOY" == "1" ]; then
     echo "Waiting for deployment to succeed."
-    if aws deploy wait deployment-successful --deployment-id "${DEPLOYMENT_ID}" --debug; then
+    if aws deploy wait deployment-successful --deployment-id "${DEPLOYMENT_ID}"; then
         echo "Deployment succeeded."
     elif [ "$ECS_PARAM_ENABLE_CIRCUIT_BREAKER" == "1" ]; then
         echo "Deployment failed. Rolling back."

--- a/src/scripts/update-bluegreen-service-via-task-def.sh
+++ b/src/scripts/update-bluegreen-service-via-task-def.sh
@@ -12,17 +12,32 @@ if [ "$ECS_PARAM_ENABLE_CIRCUIT_BREAKER" == "1" ] && [ "$ECS_PARAM_VERIFY_REV_DE
     exit 1
 fi
 
+if [ -n "$ECS_PARAM_CAPACITY_PROVIDER_NAME" ] || [ -n "$ECS_PARAM_CAPACITY_PROVIDER_WEIGHT" ] || [ -n "$ECS_PARAM_CAPACITY_PROVIDER_BASE" ]; then 
+    echo "Capacity Provider name, base and weight parameter must all be provided. Please try again"
+    exit 1
+fi 
+
+REVISION="{\"revisionType\": \"AppSpecContent\", \"appSpecContent\": {\"content\": \"{\\\"version\\\": 1, \\\"Resources\\\": [{\\\"TargetService\\\": {\\\"Type\\\": \\\"AWS::ECS::Service\\\", \\\"Properties\\\": {\\\"TaskDefinition\\\": \\\"${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN}\\\", \\\"LoadBalancerInfo\\\": {\\\"ContainerName\\\": \\\"$ECS_PARAM_CD_LOAD_BALANCED_CONTAINER_NAME\\\", \\\"ContainerPort\\\": $ECS_PARAM_CD_LOAD_BALANCED_CONTAINER_PORT}}}}]}\"}}"
+#shellcheck disable=SC2086
+# APPSPEC=$(echo '{"version":1,"Resources":[{"TargetService":{"Type":"AWS::ECS::Service","Properties":{"TaskDefinition":"'${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN}'","LoadBalancerInfo":{"ContainerName":"'${ECS_PARAM_CD_LOAD_BALANCED_CONTAINER_NAME}'","ContainerPort":"'${ECS_PARAM_CD_LOAD_BALANCED_CONTAINER_PORT}'"},"CapacityProviderStrategy":[{"CapacityProvider":"FARGATE", "Base":0, "Weight":1}]}}}}]}' | jq -Rs .)
+# REVISION='{"revisionType":"AppSpecContent","appSpecContent":{"content":'${APPSPEC}'}}'
+    # --revision "$REVISION" \
+    # --revision "{\"revisionType\": \"AppSpecContent\", \"appSpecContent\": {\"content\": \"{\\\"version\\\": 1, \\\"Resources\\\": [{\\\"TargetService\\\": {\\\"Type\\\": \\\"AWS::ECS::Service\\\", \\\"Properties\\\": {\\\"TaskDefinition\\\": \\\"${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN}\\\", \\\"LoadBalancerInfo\\\": {\\\"ContainerName\\\": \\\"$ECS_PARAM_CD_LOAD_BALANCED_CONTAINER_NAME\\\", \\\"ContainerPort\\\": $ECS_PARAM_CD_LOAD_BALANCED_CONTAINER_PORT}}}}]}\"}}" \
+
+    # --revision "{\"revisionType\": \"AppSpecContent\", \"appSpecContent\": {\"content\": \"{\\\"version\\\": 1, \\\"Resources\\\": [{\\\"TargetService\\\": {\\\"Type\\\": \\\"AWS::ECS::Service\\\", \\\"Properties\\\": {\\\"TaskDefinition\\\": \\\"${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN}\\\", \\\"LoadBalancerInfo\\\": {\\\"ContainerName\\\": \\\"$ECS_PARAM_CD_LOAD_BALANCED_CONTAINER_NAME\\\", \\\"ContainerPort\\\": $ECS_PARAM_CD_LOAD_BALANCED_CONTAINER_PORT},\\\"CapacityProviderStrategy\\\":[{\\\"CapacityProvider\\\":\\\"FARGATE\\\", \\\"Base\\\":3, \\\"Weight\\\":1}]}}}]}\"}}" \
+
 DEPLOYMENT_ID=$(aws deploy create-deployment \
     --application-name "$ECS_PARAM_CD_APP_NAME" \
     --deployment-group-name "$ECS_PARAM_CD_DEPLOY_GROUP_NAME" \
-    --revision "{\"revisionType\": \"AppSpecContent\", \"appSpecContent\": {\"content\": \"{\\\"version\\\": 1, \\\"Resources\\\": [{\\\"TargetService\\\": {\\\"Type\\\": \\\"AWS::ECS::Service\\\", \\\"Properties\\\": {\\\"TaskDefinition\\\": \\\"${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN}\\\", \\\"LoadBalancerInfo\\\": {\\\"ContainerName\\\": \\\"$ECS_PARAM_CD_LOAD_BALANCED_CONTAINER_NAME\\\", \\\"ContainerPort\\\": $ECS_PARAM_CD_LOAD_BALANCED_CONTAINER_PORT}}}}]}\"}}" \
     --query deploymentId \
-    --output text)
+    --revision "${REVISION}" \
+    --output text \
+    --debug)
 echo "Created CodeDeploy deployment: $DEPLOYMENT_ID"
 
 if [ "$ECS_PARAM_VERIFY_REV_DEPLOY" == "1" ]; then
     echo "Waiting for deployment to succeed."
-    if aws deploy wait deployment-successful --deployment-id "${DEPLOYMENT_ID}"; then
+    if aws deploy wait deployment-successful --deployment-id "${DEPLOYMENT_ID}" --debug; then
         echo "Deployment succeeded."
     elif [ "$ECS_PARAM_ENABLE_CIRCUIT_BREAKER" == "1" ]; then
         echo "Deployment failed. Rolling back."

--- a/src/scripts/update-bluegreen-service-via-task-def.sh
+++ b/src/scripts/update-bluegreen-service-via-task-def.sh
@@ -12,12 +12,18 @@ if [ "$ECS_PARAM_ENABLE_CIRCUIT_BREAKER" == "1" ] && [ "$ECS_PARAM_VERIFY_REV_DE
     exit 1
 fi
 
-if [ -n "$ECS_PARAM_CAPACITY_PROVIDER_NAME" ] || [ -n "$ECS_PARAM_CAPACITY_PROVIDER_WEIGHT" ] || [ -n "$ECS_PARAM_CAPACITY_PROVIDER_BASE" ]; then 
-    echo "Capacity Provider name, base and weight parameter must all be provided. Please try again"
-    exit 1
+if [ -n "$ECS_PARAM_CD_CAPACITY_PROVIDER_NAME" ]; then 
+    if [ -z "$ECS_PARAM_CD_CAPACITY_PROVIDER_WEIGHT" ] || [ -z "$ECS_PARAM_CD_CAPACITY_PROVIDER_BASE" ]; then 
+        echo "Capacity Provider base and weight parameter must all be provided. Please try again"
+        exit 1
+    else 
+        REVISION="{\"revisionType\": \"AppSpecContent\", \"appSpecContent\": {\"content\": \"{\\\"version\\\": 1, \\\"Resources\\\": [{\\\"TargetService\\\": {\\\"Type\\\": \\\"AWS::ECS::Service\\\", \\\"Properties\\\": {\\\"TaskDefinition\\\": \\\"${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN}\\\", \\\"LoadBalancerInfo\\\": {\\\"ContainerName\\\": \\\"$ECS_PARAM_CD_LOAD_BALANCED_CONTAINER_NAME\\\", \\\"ContainerPort\\\": $ECS_PARAM_CD_LOAD_BALANCED_CONTAINER_PORT},\\\"CapacityProviderStrategy\\\":[{\\\"CapacityProvider\\\":\\\"$ECS_PARAM_CD_CAPACITY_PROVIDER_NAME\\\", \\\"Base\\\":${ECS_PARAM_CD_CAPACITY_PROVIDER_BASE}, \\\"Weight\\\":${ECS_PARAM_CD_CAPACITY_PROVIDER_WEIGHT}}]}}}]}\"}}"
+    fi
+else
+    REVISION="{\"revisionType\": \"AppSpecContent\", \"appSpecContent\": {\"content\": \"{\\\"version\\\": 1, \\\"Resources\\\": [{\\\"TargetService\\\": {\\\"Type\\\": \\\"AWS::ECS::Service\\\", \\\"Properties\\\": {\\\"TaskDefinition\\\": \\\"${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN}\\\", \\\"LoadBalancerInfo\\\": {\\\"ContainerName\\\": \\\"$ECS_PARAM_CD_LOAD_BALANCED_CONTAINER_NAME\\\", \\\"ContainerPort\\\": $ECS_PARAM_CD_LOAD_BALANCED_CONTAINER_PORT}}}}]}\"}}"
 fi 
 
-REVISION="{\"revisionType\": \"AppSpecContent\", \"appSpecContent\": {\"content\": \"{\\\"version\\\": 1, \\\"Resources\\\": [{\\\"TargetService\\\": {\\\"Type\\\": \\\"AWS::ECS::Service\\\", \\\"Properties\\\": {\\\"TaskDefinition\\\": \\\"${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN}\\\", \\\"LoadBalancerInfo\\\": {\\\"ContainerName\\\": \\\"$ECS_PARAM_CD_LOAD_BALANCED_CONTAINER_NAME\\\", \\\"ContainerPort\\\": $ECS_PARAM_CD_LOAD_BALANCED_CONTAINER_PORT}}}}]}\"}}"
+# REVISION="{\"revisionType\": \"AppSpecContent\", \"appSpecContent\": {\"content\": \"{\\\"version\\\": 1, \\\"Resources\\\": [{\\\"TargetService\\\": {\\\"Type\\\": \\\"AWS::ECS::Service\\\", \\\"Properties\\\": {\\\"TaskDefinition\\\": \\\"${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN}\\\", \\\"LoadBalancerInfo\\\": {\\\"ContainerName\\\": \\\"$ECS_PARAM_CD_LOAD_BALANCED_CONTAINER_NAME\\\", \\\"ContainerPort\\\": $ECS_PARAM_CD_LOAD_BALANCED_CONTAINER_PORT}}}}]}\"}}"
 #shellcheck disable=SC2086
 # APPSPEC=$(echo '{"version":1,"Resources":[{"TargetService":{"Type":"AWS::ECS::Service","Properties":{"TaskDefinition":"'${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN}'","LoadBalancerInfo":{"ContainerName":"'${ECS_PARAM_CD_LOAD_BALANCED_CONTAINER_NAME}'","ContainerPort":"'${ECS_PARAM_CD_LOAD_BALANCED_CONTAINER_PORT}'"},"CapacityProviderStrategy":[{"CapacityProvider":"FARGATE", "Base":0, "Weight":1}]}}}}]}' | jq -Rs .)
 # REVISION='{"revisionType":"AppSpecContent","appSpecContent":{"content":'${APPSPEC}'}}'
@@ -31,8 +37,7 @@ DEPLOYMENT_ID=$(aws deploy create-deployment \
     --deployment-group-name "$ECS_PARAM_CD_DEPLOY_GROUP_NAME" \
     --query deploymentId \
     --revision "${REVISION}" \
-    --output text \
-    --debug)
+    --output text)
 echo "Created CodeDeploy deployment: $DEPLOYMENT_ID"
 
 if [ "$ECS_PARAM_VERIFY_REV_DEPLOY" == "1" ]; then


### PR DESCRIPTION
This PR enables the addition of a capacity provider strategy to CodeDeploy deployments.The `codedeploy-capacity-provider-name`, `codedeploy-capacity-provider-base` and `codedeploy-capacity-provider-weight` parameters must all be provided. The AppSpec file will get updated if all three parameters are provided. 

