### PR TITLE
fix: deploy-ecs-scheduled-task errors

### DIFF
--- a/src/scripts/deploy-ecs-scheduled-task.sh
+++ b/src/scripts/deploy-ecs-scheduled-task.sh
@@ -5,8 +5,8 @@ if [ -z "$td_arn" ]; then
     exit 1
 fi
 
-CLI_OUTPUT_FILE=$(mktmp cli-output.json.XXXX)
-CLI_INPUT_FILE=$(mktmp cli-input.json.XXXX)
+CLI_OUTPUT_FILE=$(mktemp cli-output.json.XXXX)
+CLI_INPUT_FILE=$(mktemp cli-input.json.XXXX)
 
 aws events list-targets-by-rule --rule "$ECS_PARAM_RULE_NAME" --output json > "$CLI_OUTPUT_FILE"
 

--- a/src/scripts/deploy-ecs-scheduled-task.sh
+++ b/src/scripts/deploy-ecs-scheduled-task.sh
@@ -16,4 +16,4 @@ if < "$CLI_OUTPUT_FILE" jq ' .Targets[] | has("EcsParameters")' | grep "false"; 
 fi
 
 < "$CLI_OUTPUT_FILE" jq --arg td_arn "$td_arn" '.Targets[].EcsParameters.TaskDefinitionArn |= $td_arn' > "$CLI_INPUT_FILE"
-aws events put-targets --cli-input-json "$(cat "$CLI_INPUT_FILE")"
+aws events put-targets --rule $ECS_PARAM_RULE_NAME --cli-input-json "$(cat "$CLI_INPUT_FILE")"


### PR DESCRIPTION
This PR applies a fix for the errors that occurs with the `deploy-ecs-scheduled-task` command.

- `bash: mktmp: command not found`
- `aws: error: the following arguments are required: --rule`