### PR TITLE
Pass profile-name through from update-service to update-task-definition

### DIFF
--- a/src/commands/update-service.yml
+++ b/src/commands/update-service.yml
@@ -165,6 +165,7 @@ steps:
             family: << parameters.family >>
             container-image-name-updates: << parameters.container-image-name-updates >>
             container-env-var-updates: << parameters.container-env-var-updates >>
+            profile-name: << parameters.profile-name >>
   - when:
       condition: << parameters.skip-task-definition-registration >>
       steps:


### PR DESCRIPTION
The profile-name was not passed from update-service to update-task-definition, resulting in the default credentials being used. This breaks when a role must be assumed to perform these actions.