### PR TITLE
fix: terraform force delete

### DIFF
--- a/tests/terraform_setup/fargate/terraform.tf
+++ b/tests/terraform_setup/fargate/terraform.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 4.13"
+      version = "~> 4.22.0"
     }
   }
   backend "s3" {
@@ -41,6 +41,7 @@ locals {
 
 resource "aws_ecr_repository" "demo-app-repository" {
   name = local.aws_ecr_repository_name
+  force_delete = true
 }
 
 resource "aws_cloudformation_stack" "vpc" {

--- a/tests/terraform_setup/fargate_codedeploy/terraform.tf
+++ b/tests/terraform_setup/fargate_codedeploy/terraform.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 4.13"
+      version = "~> 4.22.0"
     }
   }
   backend "s3" {
@@ -26,4 +26,5 @@ locals {
 
 resource "aws_ecr_repository" "demo-app-repository" {
   name = local.aws_ecr_repository_name
+  force_delete = true
 }


### PR DESCRIPTION
The latest `aws provider` version disabled automatic force delete of `aws ecr` repositories when running `terraform destroy`. This PR addresses that issue by applying `force_delete = true` to the `aws_ecr_repository` resource.