### PR TITLE
fix: added profile-name parameter

### DIFF
--- a/src/commands/update-service.yml
+++ b/src/commands/update-service.yml
@@ -165,6 +165,7 @@ steps:
             family: << parameters.family >>
             container-image-name-updates: << parameters.container-image-name-updates >>
             container-env-var-updates: << parameters.container-env-var-updates >>
+            profile-name: << parameters.profile-name >>
   - when:
       condition: << parameters.skip-task-definition-registration >>
       steps:


### PR DESCRIPTION
This PR passes the `profile-name` from the `update-service-command` through to the `update-task-definition` command. Without passing it through, any time a profile other than the `default` is used, the `update-task-definition` command fails. 