### PR TITLE
feat: implement deployment-config-name parameter

### DIFF
--- a/src/commands/update-service.yml
+++ b/src/commands/update-service.yml
@@ -156,6 +156,12 @@ parameters:
       Must be used with codedeploy-capacity-provider-name and codedeploy-capacity-provider-base.
     type: string
     default: ''
+  deployment-config-name:
+    description: >
+      The name of a CODE DEPLOY deployment configuration associated with the IAM user or AWS account.
+      If not specified, the value configured in the deployment group is used as the default.
+    type: string
+    default: ''
 
 steps:
   - unless:
@@ -210,6 +216,7 @@ steps:
               ECS_PARAM_CD_CAPACITY_PROVIDER_NAME: <<parameters.codedeploy-capacity-provider-name>>
               ECS_PARAM_CD_CAPACITY_PROVIDER_WEIGHT: <<parameters.codedeploy-capacity-provider-weight>>
               ECS_PARAM_CD_CAPACITY_PROVIDER_BASE: <<parameters.codedeploy-capacity-provider-base>>
+              ECS_PARAM_CD_DEPLOYMENT_CONFIG_NAME: <<parameters.deployment-config-name>>
 
   - when:
       condition:

--- a/src/jobs/deploy-service-update.yml
+++ b/src/jobs/deploy-service-update.yml
@@ -203,6 +203,13 @@ parameters:
       Must be used with codedeploy-capacity-provider-name and capacity-provider-base.
     type: string
     default: ''
+  deployment-config-name:
+    description: >
+      The name of a CODE DEPLOY deployment configuration associated with the IAM user or AWS account.
+      If not specified, the value configured in the deployment group is used as the default.
+    type: string
+    default: ''
+
 steps:
   - aws-cli/setup:
       aws-access-key-id: << parameters.aws-access-key-id >>
@@ -233,3 +240,4 @@ steps:
       codedeploy-capacity-provider-name: <<parameters.codedeploy-capacity-provider-name>>
       codedeploy-capacity-provider-weight: <<parameters.codedeploy-capacity-provider-weight>>
       codedeploy-capacity-provider-base: <<parameters.codedeploy-capacity-provider-base>>
+      deployment-config-name: <<parameters.deployment-config-name>>

--- a/src/scripts/update-bluegreen-service-via-task-def.sh
+++ b/src/scripts/update-bluegreen-service-via-task-def.sh
@@ -4,6 +4,7 @@ set -o noglob
 ECS_PARAM_CD_APP_NAME=$(eval echo "$ECS_PARAM_CD_APP_NAME")
 ECS_PARAM_CD_DEPLOY_GROUP_NAME=$(eval echo "$ECS_PARAM_CD_DEPLOY_GROUP_NAME")
 ECS_PARAM_CD_LOAD_BALANCED_CONTAINER_NAME=$(eval echo "$ECS_PARAM_CD_LOAD_BALANCED_CONTAINER_NAME")
+ECS_PARAM_CD_DEPLOYMENT_CONFIG_NAME=$(eval echo "$ECS_PARAM_CD_DEPLOYMENT_CONFIG_NAME")
 
 DEPLOYED_REVISION="${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN}"
 
@@ -23,12 +24,18 @@ else
     REVISION="{\"revisionType\": \"AppSpecContent\", \"appSpecContent\": {\"content\": \"{\\\"version\\\": 1, \\\"Resources\\\": [{\\\"TargetService\\\": {\\\"Type\\\": \\\"AWS::ECS::Service\\\", \\\"Properties\\\": {\\\"TaskDefinition\\\": \\\"${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN}\\\", \\\"LoadBalancerInfo\\\": {\\\"ContainerName\\\": \\\"$ECS_PARAM_CD_LOAD_BALANCED_CONTAINER_NAME\\\", \\\"ContainerPort\\\": $ECS_PARAM_CD_LOAD_BALANCED_CONTAINER_PORT}}}}]}\"}}"
 fi 
 
+if [ -n "$ECS_PARAM_CD_DEPLOYMENT_CONFIG_NAME" ]; then
+    set -- "$@" --deployment-config-name "${ECS_PARAM_CD_DEPLOYMENT_CONFIG_NAME}"
+fi
+
 DEPLOYMENT_ID=$(aws deploy create-deployment \
     --application-name "$ECS_PARAM_CD_APP_NAME" \
     --deployment-group-name "$ECS_PARAM_CD_DEPLOY_GROUP_NAME" \
     --query deploymentId \
     --revision "${REVISION}" \
+    "$@" \
     --output text)
+
 echo "Created CodeDeploy deployment: $DEPLOYMENT_ID"
 
 if [ "$ECS_PARAM_VERIFY_REV_DEPLOY" == "1" ]; then


### PR DESCRIPTION
This PR adds the `deployment-config-name` parameter to the `update-service` command and `deploy-service-update` job. It enables users to add a predefined deployment configuration when creating a Blue/Green Deployment in CodeDeploy and resolves issue #159.