### PR TITLE
fix: Allow running multiple `run-task` with overrides

### DIFF
--- a/src/scripts/run-task.sh
+++ b/src/scripts/run-task.sh
@@ -9,7 +9,9 @@ if ! command -v envsubst && [[ "$ECS_PARAM_OVERRIDES" == *"\${"* ]]; then
     curl -L https://github.com/a8m/envsubst/releases/download/v1.2.0/envsubst-"$(uname -s)"-"$(uname -m)" -o envsubst
     $SUDO chmod +x envsubst
     $SUDO mv envsubst /usr/local/bin
-    ECS_PARAM_OVERRIDES=$(echo "${ECS_PARAM_OVERRIDES}" | envsubst)
+fi
+if [[ "$ECS_PARAM_OVERRIDES" == *"\${"* ]]; then
+    ECS_PARAM_OVERRIDES="$(echo "${ECS_PARAM_OVERRIDES}" | envsubst)"
 fi
 
 set -o noglob


### PR DESCRIPTION
Fixes a bug where 2 consecutive `aws-ecs/run-task` commands with container `overrides` would only end up substituting environment variables in the former. `envsubst` was only runned at most once in a single job invocation due to incorrect condition logic.