### PR TITLE
eval ECS_PARAM_RULE_NAME

### DIFF
--- a/src/scripts/deploy-ecs-scheduled-task.sh
+++ b/src/scripts/deploy-ecs-scheduled-task.sh
@@ -1,3 +1,6 @@
+# These variables are evaluated so the config file may contain and pass in environment variables to the parameters.
+ECS_PARAM_RULE_NAME=$(eval echo "$ECS_PARAM_RULE_NAME")
+
 td_arn=$CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN
 
 if [ -z "$td_arn" ]; then
@@ -16,4 +19,4 @@ if < "$CLI_OUTPUT_FILE" jq ' .Targets[] | has("EcsParameters")' | grep "false"; 
 fi
 
 < "$CLI_OUTPUT_FILE" jq --arg td_arn "$td_arn" '.Targets[].EcsParameters.TaskDefinitionArn |= $td_arn' > "$CLI_INPUT_FILE"
-aws events put-targets --rule $ECS_PARAM_RULE_NAME --cli-input-json "$(cat "$CLI_INPUT_FILE")"
+aws events put-targets --rule "$ECS_PARAM_RULE_NAME" --cli-input-json "$(cat "$CLI_INPUT_FILE")"


### PR DESCRIPTION
I'm getting this error:
```
An error occurred (ValidationException) when calling the ListTargetsByRule operation: 1 validation error detected: Value '${CIRCLE_BRANCH}-zambas-scheduled-task' at 'rule' failed to satisfy constraint: Member must satisfy regular expression pattern: [\.\-_A-Za-z0-9]+

Exited with code exit status 254
```

So, I'm adding the `eval` to evaluated the `ECS_PARAM_RULE_NAME` variable so the config file may contain and pass in environment variables to the parameters.