### PR TITLE
feat!/auth-step-parameter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 setup: true
 orbs:
-  orb-tools: circleci/orb-tools@11.1
+  orb-tools: circleci/orb-tools@11.6
   shellcheck: circleci/shellcheck@3.1
 
 filters: &filters

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -438,16 +438,16 @@ jobs:
 workflows:
   test-deploy:
     jobs:
-      # # Make sure to include "filters: *filters" in every test job you want to run as part of your deployment.
-      # - integration-test-ecs-cli-install:
-      #     version: "v1.9.0"
-      #     matrix:
-      #       parameters:
-      #         executor: [linux, mac]
-      #     filters: *filters
-      # # #################
-      # # # Fargate
-      # # #################
+      # Make sure to include "filters: *filters" in every test job you want to run as part of your deployment.
+      - integration-test-ecs-cli-install:
+          version: "v1.9.0"
+          matrix:
+            parameters:
+              executor: [linux, mac]
+          filters: *filters
+      #################
+      # Fargate
+      #################
       - build-test-app:
           name: fargate_build-test-app
           docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
@@ -531,112 +531,112 @@ workflows:
           context: [CPE-OIDC]
           role-arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
 
-      # #################
-      # # EC2
-      # #################
-      # - build-test-app:
-      #     name: ec2_build-test-app
-      #     docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
-      #     docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}:${CIRCLE_SHA1}"
-      #     context: [CPE-OIDC]
-      #     filters: *filters
-      # - set-up-test-env:
-      #     name: ec2_set-up-test-env
-      #     filters: *filters
-      #     requires:
-      #       - ec2_build-test-app
-      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
-      #     terraform-config-dir: "tests/terraform_setup/ec2"
-      #     context: [CPE-OIDC]
-      #     role-arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
-      # - set-up-run-task-test:
-      #     name: ec2_set-up-run-task-test
-      #     filters: *filters
-      #     requires:
-      #       - ec2_set-up-test-env
-      #     family-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360"
-      #     context: [CPE-OIDC]
-      #     role-arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
-      # - aws-ecs/run-task:
-      #     name: ec2_run-task-test
-      #     auth:
-      #       - aws-cli/setup:
-      #           role-arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
-      #     filters: *filters
-      #     requires:
-      #       - ec2_set-up-run-task-test
-      #     cluster: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
-      #     task-definition: "${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360"
-      #     launch-type: "EC2"
-      #     awsvpc: false
-      #     run-task-output: "run-task-output.json"
-      #     overrides: '{"containerOverrides":[{"name": "${INTERPOLATION_TEST}", "memory": 512}]}'
-      #     context: [CPE-OIDC]
-      # - tear-down-run-task-test:
-      #     name: ec2_tear-down-run-task-test
-      #     filters: *filters
-      #     requires:
-      #       - ec2_run-task-test
-      #     family-name: ${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360
-      #     context: [CPE-OIDC]
-      #     role-arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
-      # - test-service-update:
-      #     name: ec2_test-update-service-command
-      #     filters: *filters
-      #     requires:
-      #       - ec2_set-up-test-env
-      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
-      #     family-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
-      #     service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
-      #     docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
-      #     docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}:${CIRCLE_SHA1}"
-      #     context: [CPE-OIDC]
-      #     role-arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
-      # - test-task-definition-update:
-      #     name: ec2_test-task-definition-update
-      #     family-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
-      #     context: [CPE-OIDC]
-      #     role-arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
-      #     filters: *filters
-      #     requires:
-      #       - ec2_test-update-service-command
-      # - aws-ecs/deploy-service-update:
-      #     name: ec2_test-update-service-job
-      #     auth:
-      #       - aws-cli/setup:
-      #           role-arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
-      #           profile-name: "ECS_TEST_PROFILE"
-      #     profile-name: "ECS_TEST_PROFILE"
-      #     docker-image-for-job: cimg/python:3.10.4
-      #     context: [CPE-OIDC]
-      #     filters: *filters
-      #     requires:
-      #       - ec2_test-task-definition-update
-      #     family: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
-      #     service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
-      #     cluster: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
-      #     container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_EC2}-service,name=VERSION_INFO,value="Asterisk * expansion test ${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_EC2}-service,name=BUILD_DATE,value=$(date)'
-      #     verify-revision-is-deployed: true
-      #     fail-on-verification-timeout: false
-      #     post-steps:
-      #       - test-deployment:
-      #           service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
-      #           cluster: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
-      #           test-asterisk-expansion: true
-      # - tear-down-test-env:
-      #     name: ec2_tear-down-test-env
-      #     filters: *filters
-      #     requires:
-      #       - ec2_test-update-service-job
-      #       - ec2_tear-down-run-task-test
-      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
-      #     terraform-config-dir: "tests/terraform_setup/ec2"
-      #     context: [CPE-OIDC]
-      #     role-arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+      #################
+      # EC2
+      #################
+      - build-test-app:
+          name: ec2_build-test-app
+          docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+          docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}:${CIRCLE_SHA1}"
+          context: [CPE-OIDC]
+          filters: *filters
+      - set-up-test-env:
+          name: ec2_set-up-test-env
+          filters: *filters
+          requires:
+            - ec2_build-test-app
+          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
+          terraform-config-dir: "tests/terraform_setup/ec2"
+          context: [CPE-OIDC]
+          role-arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+      - set-up-run-task-test:
+          name: ec2_set-up-run-task-test
+          filters: *filters
+          requires:
+            - ec2_set-up-test-env
+          family-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360"
+          context: [CPE-OIDC]
+          role-arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+      - aws-ecs/run-task:
+          name: ec2_run-task-test
+          auth:
+            - aws-cli/setup:
+                role-arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+          filters: *filters
+          requires:
+            - ec2_set-up-run-task-test
+          cluster: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
+          task-definition: "${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360"
+          launch-type: "EC2"
+          awsvpc: false
+          run-task-output: "run-task-output.json"
+          overrides: '{"containerOverrides":[{"name": "${INTERPOLATION_TEST}", "memory": 512}]}'
+          context: [CPE-OIDC]
+      - tear-down-run-task-test:
+          name: ec2_tear-down-run-task-test
+          filters: *filters
+          requires:
+            - ec2_run-task-test
+          family-name: ${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360
+          context: [CPE-OIDC]
+          role-arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+      - test-service-update:
+          name: ec2_test-update-service-command
+          filters: *filters
+          requires:
+            - ec2_set-up-test-env
+          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
+          family-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
+          service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
+          docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+          docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}:${CIRCLE_SHA1}"
+          context: [CPE-OIDC]
+          role-arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+      - test-task-definition-update:
+          name: ec2_test-task-definition-update
+          family-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
+          context: [CPE-OIDC]
+          role-arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+          filters: *filters
+          requires:
+            - ec2_test-update-service-command
+      - aws-ecs/deploy-service-update:
+          name: ec2_test-update-service-job
+          auth:
+            - aws-cli/setup:
+                role-arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+                profile-name: "ECS_TEST_PROFILE"
+          profile-name: "ECS_TEST_PROFILE"
+          docker-image-for-job: cimg/python:3.10.4
+          context: [CPE-OIDC]
+          filters: *filters
+          requires:
+            - ec2_test-task-definition-update
+          family: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
+          service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
+          cluster: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
+          container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_EC2}-service,name=VERSION_INFO,value="Asterisk * expansion test ${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_EC2}-service,name=BUILD_DATE,value=$(date)'
+          verify-revision-is-deployed: true
+          fail-on-verification-timeout: false
+          post-steps:
+            - test-deployment:
+                service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
+                cluster: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
+                test-asterisk-expansion: true
+      - tear-down-test-env:
+          name: ec2_tear-down-test-env
+          filters: *filters
+          requires:
+            - ec2_test-update-service-job
+            - ec2_tear-down-run-task-test
+          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
+          terraform-config-dir: "tests/terraform_setup/ec2"
+          context: [CPE-OIDC]
+          role-arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
 
-      #################
+      # ################
       # FargateSpot
-      #################
+      # ################
 
       - test-fargatespot:
           context: [CPE-OIDC]
@@ -648,125 +648,125 @@ workflows:
       #################
       # CodeDeploy
       #################
-      # - build-test-app:
-      #     name: codedeploy_fargate_build-test-app
-      #     docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
-      #     docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
-      #     context: [CPE-OIDC]
-      #     filters: *filters
-      # - set-up-test-env:
-      #     name: codedeploy_fargate_set-up-test-env
-      #     filters: *filters
-      #     requires:
-      #       - codedeploy_fargate_build-test-app
-      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
-      #     terraform-config-dir: "tests/terraform_setup/fargate_codedeploy"
-      #     context: [CPE-OIDC]
-      #     role-arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST" 
-      # - test-service-update:
-      #     name: codedeploy_fargate_test-update-service-command
-      #     filters: *filters
-      #     requires:
-      #       - codedeploy_fargate_set-up-test-env
-      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
-      #     family-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-      #     service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-      #     docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
-      #     docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
-      #     role-arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
-      #     skip-service-update: true
-      #     context: [CPE-OIDC]
-      # - aws-ecs/deploy-service-update:
-      #     name: codedeploy_fargate_test-update-service-job
-      #     auth:
-      #       - aws-cli/setup:
-      #           role-arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
-      #           profile-name: "ECS_TEST_PROFILE"
-      #     profile-name: "ECS_TEST_PROFILE"
-      #     docker-image-for-job: cimg/python:3.10.4
-      #     filters: *filters
-      #     requires:
-      #       - codedeploy_fargate_test-update-service-command
-      #     family: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-      #     cluster: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
-      #     container-image-name-updates: "container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,image-and-tag=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
-      #     container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=BUILD_DATE,value=$(date)'
-      #     deployment-controller: "CODE_DEPLOY"
-      #     codedeploy-application-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeployapp"
-      #     codedeploy-deployment-group-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
-      #     codedeploy-load-balanced-container-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-      #     codedeploy-load-balanced-container-port: 8080
-      #     codedeploy-capacity-provider-name: "FARGATE"
-      #     codedeploy-capacity-provider-base: "1"
-      #     codedeploy-capacity-provider-weight: "2"
-      #     verify-revision-is-deployed: false
-      #     context: [CPE-OIDC]
-      #     post-steps:
-      #       - wait-for-codedeploy-deployment:
-      #           application-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeployapp"
-      #           deployment-group-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
-      #       - test-deployment:
-      #           service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-      #           cluster: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
-      #           delete-load-balancer: false
-      # - aws-ecs/deploy-service-update:
-      #     name: codedeploy_fargate_test-update-and-wait-service-job
-      #     auth:
-      #       - aws-cli/setup:
-      #           role-arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
-      #           profile-name: "ECS_TEST_PROFILE"
-      #     profile-name: "ECS_TEST_PROFILE"        
-      #     docker-image-for-job: cimg/python:3.10.4
-      #     context: [CPE-OIDC]
-      #     filters: *filters
-      #     requires:
-      #       - codedeploy_fargate_test-update-service-job
-      #     family: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-      #     cluster: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
-      #     container-image-name-updates: "container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,image-and-tag=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
-      #     container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=BUILD_DATE,value=$(date)'
-      #     deployment-controller: "CODE_DEPLOY"
-      #     codedeploy-application-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeployapp"
-      #     codedeploy-deployment-group-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
-      #     codedeploy-load-balanced-container-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-      #     codedeploy-load-balanced-container-port: 8080
-      #     verify-revision-is-deployed: true
-      #     verification-timeout: "12m"
-      #     post-steps:
-      #       - test-deployment:
-      #           service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-      #           cluster: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
-      #           delete-load-balancer: true
-      #       - delete-service:
-      #           service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-      #           cluster: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
-      # - tear-down-test-env:
-      #     name: codedeploy_fargate_tear-down-test-env
-      #     requires:
-      #       - codedeploy_fargate_test-update-and-wait-service-job
-      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
-      #     terraform-config-dir: "tests/terraform_setup/fargate_codedeploy"
-      #     context: [CPE-OIDC]
-      #     role-arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
-      #     filters: *filters
-      # - orb-tools/pack:
-      #     filters: *filters
-      # - orb-tools/publish:
-      #     orb-name: circleci/aws-ecs
-      #     vcs-type: << pipeline.project.type >>
-      #     pub-type: production
-      #     requires:
-      #       - orb-tools/pack
-      #       - ec2_tear-down-test-env
-      #       - fargate_tear-down-test-env  
-      #       - codedeploy_fargate_tear-down-test-env
-      #       - integration-test-ecs-cli-install
-      #     context: orb-publisher
-      #     filters:
-      #       branches:
-      #         ignore: /.*/
-      #       tags:
-      #         only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
+      - build-test-app:
+            name: codedeploy_fargate_build-test-app
+            docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com"
+            docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
+            context: [CPE-OIDC]
+            filters: *filters
+      - set-up-test-env:
+          name: codedeploy_fargate_set-up-test-env
+          filters: *filters
+          requires:
+            - codedeploy_fargate_build-test-app
+          terraform-image: "hashicorp/terraform:1.4.0"
+          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
+          terraform-config-dir: "tests/terraform_setup/fargate_codedeploy"
+          context: [CPE-OIDC]
+          role-arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST" 
+      - test-service-update:
+          name: codedeploy_fargate_test-update-service-command
+          filters: *filters
+          requires:
+            - codedeploy_fargate_set-up-test-env
+          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
+          family-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+          service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+          docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com"
+          docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
+          role-arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+          skip-service-update: true
+          context: [CPE-OIDC]
+      - aws-ecs/deploy-service-update:
+          name: codedeploy_fargate_test-update-service-job
+          auth:
+            - aws-cli/setup:
+                role-arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+          docker-image-for-job: cimg/python:3.10.4
+          filters: *filters
+          requires:
+            - codedeploy_fargate_test-update-service-command
+          aws-region: AWS_REGION
+          family: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+          cluster: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+          container-image-name-updates: "container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,image-and-tag=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
+          container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=BUILD_DATE,value=$(date)'
+          deployment-controller: "CODE_DEPLOY"
+          codedeploy-application-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeployapp"
+          codedeploy-deployment-group-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
+          codedeploy-load-balanced-container-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+          codedeploy-load-balanced-container-port: 80
+          codedeploy-capacity-provider-name: "FARGATE"
+          codedeploy-capacity-provider-base: "1"
+          codedeploy-capacity-provider-weight: "2"
+          verify-revision-is-deployed: false
+          context: [CPE-OIDC]
+          post-steps:
+            - wait-for-codedeploy-deployment:
+                application-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeployapp"
+                deployment-group-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
+            - test-deployment:
+                service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+                cluster: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+                delete-load-balancer: false
+      - aws-ecs/deploy-service-update:
+          name: codedeploy_fargate_test-update-and-wait-service-job
+          auth:
+            - aws-cli/setup:
+                role-arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"          
+          docker-image-for-job: cimg/python:3.10.4
+          context: [CPE-OIDC]
+          filters: *filters
+          requires:
+            - codedeploy_fargate_test-update-service-job
+          aws-region: AWS_REGION
+          family: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+          cluster: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+          container-image-name-updates: "container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,image-and-tag=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
+          container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=BUILD_DATE,value=$(date)'
+          deployment-controller: "CODE_DEPLOY"
+          codedeploy-application-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeployapp"
+          codedeploy-deployment-group-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
+          codedeploy-load-balanced-container-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+          codedeploy-load-balanced-container-port: 80
+          verify-revision-is-deployed: true
+          verification-timeout: "12m"
+          post-steps:
+            - test-deployment:
+                service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+                cluster: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+                delete-load-balancer: true
+            - delete-service:
+                service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+                cluster: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+      - tear-down-test-env:
+          name: codedeploy_fargate_tear-down-test-env
+          requires:
+            - codedeploy_fargate_test-update-and-wait-service-job
+          terraform-image: "hashicorp/terraform:1.4.0"
+          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
+          terraform-config-dir: "tests/terraform_setup/fargate_codedeploy"
+          context: [CPE-OIDC]
+          role-arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+          filters: *filters
+      - orb-tools/pack:
+          filters: *filters
+      - orb-tools/publish:
+          orb-name: circleci/aws-ecs
+          vcs-type: << pipeline.project.type >>
+          pub-type: production
+          requires:
+            - orb-tools/pack
+            - ec2_tear-down-test-env
+            - fargate_tear-down-test-env  
+            - codedeploy_fargate_tear-down-test-env
+            - integration-test-ecs-cli-install
+          context: orb-publisher
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
 commands:
   wait-for-codedeploy-deployment:
     description: "Wait for the CodeDeploy deployment to be successful"

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -1,8 +1,8 @@
 version: 2.1
 orbs:
   aws-ecs: circleci/aws-ecs@dev:<<pipeline.git.revision>>
-  orb-tools: circleci/orb-tools@11.1
-  aws-cli: circleci/aws-cli@3.1
+  orb-tools: circleci/orb-tools@11.6
+  aws-cli: circleci/aws-cli@3.1.5
   jq: circleci/jq@2.2
 
 filters: &filters
@@ -68,7 +68,7 @@ jobs:
               --cluster "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster" \
               --capacity-providers FARGATE FARGATE_SPOT  \
               --default-capacity-provider-strategy capacityProvider=FARGATE,weight=1 \
-              --region ${AWS_REGION}
+              --region ${AWS_DEFAULT_REGION}
       - run:
           name: Register task definition
           command: |
@@ -111,14 +111,18 @@ jobs:
       - run:
           name: Test image
           command: |
-            docker run -d -p 8080:8080 --name built-image <<parameters.docker-image-namespace>>/<<parameters.docker-image-name>>
+            set -x
+            docker run -d -p 8080:80 --name built-image <<parameters.docker-image-namespace>>/<<parameters.docker-image-name>>
             sleep 10
-            docker run --network container:built-image appropriate/curl --retry 10 --retry-connrefused http://localhost:8080 | grep "Hello World!"
+            docker run --network container:built-image appropriate/curl --retry 10 --retry-connrefused http://localhost:80 | grep "Hello World!"
+            set +x
       - run:
           name: Save image to an archive
           command: |
             mkdir -p docker-images/<<parameters.docker-image-name>>
+            set -x
             docker save -o docker-images/<<parameters.docker-image-name>>/<<parameters.docker-image-name>>.tar <<parameters.docker-image-namespace>>/<<parameters.docker-image-name>>
+            set +x
       - persist_to_workspace:
           root: .
           paths:
@@ -127,7 +131,7 @@ jobs:
     parameters:
       terraform-image:
         type: string
-        default: "hashicorp/terraform:1.1.9"
+        default: "hashicorp/terraform:1.4.0"
       aws-resource-name-prefix:
         type: string
       terraform-config-dir:
@@ -156,35 +160,38 @@ jobs:
               circleci step halt
             fi
       - checkout
-      - when: 
-          condition: << parameters.role-arn >>
-          steps:
-            - aws-cli/setup:
-                profile-name: << parameters.profile-name >>
-                role-arn: << parameters.role-arn >>
+      - aws-cli/setup:
+          profile-name: << parameters.profile-name >>
+          role-arn: << parameters.role-arn >>
       - run:
           name: terraform init
           command: |
+            set -x
             cd << parameters.terraform-config-dir >>
             terraform init -input=false
+            set +x
       - run:
           name: terraform plan
           command: |
             cd << parameters.terraform-config-dir >>
+            set -x
             terraform plan \
                 -input=false \
                 -var "aws_access_key=${AWS_ACCESS_KEY_ID}" \
                 -var "aws_secret_key=${AWS_SECRET_ACCESS_KEY}" \
                 -var "aws_session_token=${AWS_SESSION_TOKEN}" \
-                -var "aws_region=${AWS_REGION}" \
+                -var "aws_region=${AWS_DEFAULT_REGION}" \
                 -var "aws_account_id=${AWS_ACCOUNT_ID}" \
                 -var "aws_resource_prefix=<< parameters.aws-resource-name-prefix >>" \
                 -out tfplan
+            set +x
       - run:
           name: terraform apply
           command: |
+            set -x
             cd << parameters.terraform-config-dir >>
             terraform apply -input=false -auto-approve tfplan
+            set +x
   test-service-update:
     docker:
       - image: cimg/python:3.10.4
@@ -233,11 +240,11 @@ jobs:
             echo 'export ECR_REPOSITORY_NAME="<< parameters.aws-resource-name-prefix >>"' >> $BASH_ENV
             echo 'export ECS_CLUSTER_NAME="<< parameters.aws-resource-name-prefix >>-cluster"' >> $BASH_ENV
             echo 'export ECS_SERVICE_NAME="<< parameters.aws-resource-name-prefix >>-service"' >> $BASH_ENV
-            echo 'export FULL_IMAGE_NAME="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${ECR_REPOSITORY_NAME}:${CIRCLE_SHA1}"' >> $BASH_ENV
+            echo 'export FULL_IMAGE_NAME="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${ECR_REPOSITORY_NAME}:${CIRCLE_SHA1}"' >> $BASH_ENV
       - run:
           name: Push image
           command: |
-            aws ecr get-login-password --region $AWS_REGION --profile "<<parameters.profile-name>>" | docker login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com
+            aws ecr get-login-password --region $AWS_DEFAULT_REGION --profile "<<parameters.profile-name>>" | docker login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com
             docker push $FULL_IMAGE_NAME
       - unless:
           condition: << parameters.skip-service-update >>
@@ -275,7 +282,7 @@ jobs:
       - aws-cli/setup:
           profile-name: << parameters.profile-name >>
           role-arn: << parameters.role-arn >>
-          aws-region: AWS_REGION
+          aws-region: AWS_DEFAULT_REGION
       - run:
           name: Get existing task definition
           command: |
@@ -308,7 +315,7 @@ jobs:
       - aws-cli/setup:
           role-arn: << parameters.role-arn >>
           profile-name: << parameters.profile-name >>
-          aws-region: AWS_REGION
+          aws-region: AWS_DEFAULT_REGION
       - run:
           name: Register task definition
           command: |
@@ -334,7 +341,7 @@ jobs:
       - aws-cli/setup:
           profile-name: << parameters.profile-name >>
           role-arn: << parameters.role-arn >>
-          aws-region: AWS_REGION
+          aws-region: AWS_DEFAULT_REGION
       - run:
           name: Deregister task definition
           command: |
@@ -345,7 +352,7 @@ jobs:
     parameters:
       terraform-image:
         type: string
-        default: hashicorp/terraform:1.1.9
+        default: "hashicorp/terraform:1.4.0"
       aws-resource-name-prefix:
         type: string
       terraform-config-dir:
@@ -431,19 +438,19 @@ jobs:
 workflows:
   test-deploy:
     jobs:
-      # Make sure to include "filters: *filters" in every test job you want to run as part of your deployment.
-      - integration-test-ecs-cli-install:
-          version: "v1.9.0"
-          matrix:
-            parameters:
-              executor: [linux, mac]
-          filters: *filters
-      # #################
-      # # Fargate
-      # #################
+      # # Make sure to include "filters: *filters" in every test job you want to run as part of your deployment.
+      # - integration-test-ecs-cli-install:
+      #     version: "v1.9.0"
+      #     matrix:
+      #       parameters:
+      #         executor: [linux, mac]
+      #     filters: *filters
+      # # #################
+      # # # Fargate
+      # # #################
       - build-test-app:
           name: fargate_build-test-app
-          docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com"
+          docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
           docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}:${CIRCLE_SHA1}"
           context: [CPE-OIDC]
           filters: *filters
@@ -464,18 +471,20 @@ workflows:
           aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
           family-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
           service-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
-          docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com"
+          docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
           docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}:${CIRCLE_SHA1}"
           context: [CPE-OIDC]
           role-arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
       - aws-ecs/deploy-service-update:
           name: fargate_test-update-service-job
+          auth:
+            - aws-cli/setup:
+                role-arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+                profile-name: "ECS_TEST_PROFILE"
           docker-image-for-job: cimg/python:3.10.4
           filters: *filters
           requires:
             - fargate_test-update-service-command
-          aws-access-key-id: AWS_ACCESS_KEY_ID
-          aws-region: AWS_REGION
           profile-name: "ECS_TEST_PROFILE"
           family: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
           cluster: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
@@ -486,19 +495,20 @@ workflows:
           max-poll-attempts: 40
           poll-interval: 10
           context: [CPE-OIDC]
-          role-arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
           post-steps:
             - test-deployment:
                 service-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
                 cluster: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
       - aws-ecs/deploy-service-update:
           name: fargate_test-update-service-skip-registration
+          auth:
+            - aws-cli/setup:
+                role-arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+                profile-name: "ECS_TEST_PROFILE"          
           docker-image-for-job: cimg/python:3.10.4
           filters: *filters
           requires:
             - fargate_test-update-service-job
-          aws-access-key-id: AWS_ACCESS_KEY_ID
-          aws-region: AWS_REGION
           profile-name: "ECS_TEST_PROFILE"
           family: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
           cluster: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
@@ -510,7 +520,6 @@ workflows:
           max-poll-attempts: 40
           poll-interval: 10
           context: [CPE-OIDC]
-          role-arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
       - tear-down-test-env:
           name: fargate_tear-down-test-env
           filters: *filters
@@ -525,102 +534,105 @@ workflows:
       # #################
       # # EC2
       # #################
-      - build-test-app:
-          name: ec2_build-test-app
-          docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com"
-          docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}:${CIRCLE_SHA1}"
-          context: [CPE-OIDC]
-          filters: *filters
-      - set-up-test-env:
-          name: ec2_set-up-test-env
-          filters: *filters
-          requires:
-            - ec2_build-test-app
-          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
-          terraform-config-dir: "tests/terraform_setup/ec2"
-          context: [CPE-OIDC]
-          role-arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
-      - set-up-run-task-test:
-          name: ec2_set-up-run-task-test
-          filters: *filters
-          requires:
-            - ec2_set-up-test-env
-          family-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360"
-          context: [CPE-OIDC]
-          role-arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
-      - aws-ecs/run-task:
-          name: ec2_run-task-test
-          filters: *filters
-          requires:
-            - ec2_set-up-run-task-test
-          cluster: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
-          aws-region: AWS_REGION
-          task-definition: "${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360"
-          launch-type: "EC2"
-          awsvpc: false
-          run-task-output: "run-task-output.json"
-          overrides: '{"containerOverrides":[{"name": "${INTERPOLATION_TEST}", "memory": 512}]}'
-          context: [CPE-OIDC]
-          role-arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
-      - tear-down-run-task-test:
-          name: ec2_tear-down-run-task-test
-          filters: *filters
-          requires:
-            - ec2_run-task-test
-          family-name: ${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360
-          context: [CPE-OIDC]
-          role-arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
-      - test-service-update:
-          name: ec2_test-update-service-command
-          filters: *filters
-          requires:
-            - ec2_set-up-test-env
-          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
-          family-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
-          service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
-          docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com"
-          docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}:${CIRCLE_SHA1}"
-          context: [CPE-OIDC]
-          role-arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
-      - test-task-definition-update:
-          name: ec2_test-task-definition-update
-          family-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
-          context: [CPE-OIDC]
-          role-arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
-          filters: *filters
-          requires:
-            - ec2_test-update-service-command
-      - aws-ecs/deploy-service-update:
-          name: ec2_test-update-service-job
-          docker-image-for-job: cimg/python:3.10.4
-          context: [CPE-OIDC]
-          role-arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
-          filters: *filters
-          requires:
-            - ec2_test-task-definition-update
-          aws-access-key-id: AWS_ACCESS_KEY_ID
-          aws-region: AWS_REGION
-          family: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
-          service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
-          cluster: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
-          container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_EC2}-service,name=VERSION_INFO,value="Asterisk * expansion test ${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_EC2}-service,name=BUILD_DATE,value=$(date)'
-          verify-revision-is-deployed: true
-          fail-on-verification-timeout: false
-          post-steps:
-            - test-deployment:
-                service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
-                cluster: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
-                test-asterisk-expansion: true
-      - tear-down-test-env:
-          name: ec2_tear-down-test-env
-          filters: *filters
-          requires:
-            - ec2_test-update-service-job
-            - ec2_tear-down-run-task-test
-          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
-          terraform-config-dir: "tests/terraform_setup/ec2"
-          context: [CPE-OIDC]
-          role-arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+      # - build-test-app:
+      #     name: ec2_build-test-app
+      #     docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+      #     docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}:${CIRCLE_SHA1}"
+      #     context: [CPE-OIDC]
+      #     filters: *filters
+      # - set-up-test-env:
+      #     name: ec2_set-up-test-env
+      #     filters: *filters
+      #     requires:
+      #       - ec2_build-test-app
+      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
+      #     terraform-config-dir: "tests/terraform_setup/ec2"
+      #     context: [CPE-OIDC]
+      #     role-arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+      # - set-up-run-task-test:
+      #     name: ec2_set-up-run-task-test
+      #     filters: *filters
+      #     requires:
+      #       - ec2_set-up-test-env
+      #     family-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360"
+      #     context: [CPE-OIDC]
+      #     role-arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+      # - aws-ecs/run-task:
+      #     name: ec2_run-task-test
+      #     auth:
+      #       - aws-cli/setup:
+      #           role-arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+      #     filters: *filters
+      #     requires:
+      #       - ec2_set-up-run-task-test
+      #     cluster: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
+      #     task-definition: "${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360"
+      #     launch-type: "EC2"
+      #     awsvpc: false
+      #     run-task-output: "run-task-output.json"
+      #     overrides: '{"containerOverrides":[{"name": "${INTERPOLATION_TEST}", "memory": 512}]}'
+      #     context: [CPE-OIDC]
+      # - tear-down-run-task-test:
+      #     name: ec2_tear-down-run-task-test
+      #     filters: *filters
+      #     requires:
+      #       - ec2_run-task-test
+      #     family-name: ${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360
+      #     context: [CPE-OIDC]
+      #     role-arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+      # - test-service-update:
+      #     name: ec2_test-update-service-command
+      #     filters: *filters
+      #     requires:
+      #       - ec2_set-up-test-env
+      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
+      #     family-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
+      #     service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
+      #     docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+      #     docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}:${CIRCLE_SHA1}"
+      #     context: [CPE-OIDC]
+      #     role-arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+      # - test-task-definition-update:
+      #     name: ec2_test-task-definition-update
+      #     family-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
+      #     context: [CPE-OIDC]
+      #     role-arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+      #     filters: *filters
+      #     requires:
+      #       - ec2_test-update-service-command
+      # - aws-ecs/deploy-service-update:
+      #     name: ec2_test-update-service-job
+      #     auth:
+      #       - aws-cli/setup:
+      #           role-arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+      #           profile-name: "ECS_TEST_PROFILE"
+      #     profile-name: "ECS_TEST_PROFILE"
+      #     docker-image-for-job: cimg/python:3.10.4
+      #     context: [CPE-OIDC]
+      #     filters: *filters
+      #     requires:
+      #       - ec2_test-task-definition-update
+      #     family: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
+      #     service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
+      #     cluster: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
+      #     container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_EC2}-service,name=VERSION_INFO,value="Asterisk * expansion test ${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_EC2}-service,name=BUILD_DATE,value=$(date)'
+      #     verify-revision-is-deployed: true
+      #     fail-on-verification-timeout: false
+      #     post-steps:
+      #       - test-deployment:
+      #           service-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
+      #           cluster: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
+      #           test-asterisk-expansion: true
+      # - tear-down-test-env:
+      #     name: ec2_tear-down-test-env
+      #     filters: *filters
+      #     requires:
+      #       - ec2_test-update-service-job
+      #       - ec2_tear-down-run-task-test
+      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
+      #     terraform-config-dir: "tests/terraform_setup/ec2"
+      #     context: [CPE-OIDC]
+      #     role-arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
 
       #################
       # FargateSpot
@@ -636,121 +648,125 @@ workflows:
       #################
       # CodeDeploy
       #################
-      - build-test-app:
-          name: codedeploy_fargate_build-test-app
-          docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com"
-          docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
-          context: [CPE-OIDC]
-          filters: *filters
-      - set-up-test-env:
-          name: codedeploy_fargate_set-up-test-env
-          filters: *filters
-          requires:
-            - codedeploy_fargate_build-test-app
-          terraform-image: "hashicorp/terraform:1.1.9"
-          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
-          terraform-config-dir: "tests/terraform_setup/fargate_codedeploy"
-          context: [CPE-OIDC]
-          role-arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST" 
-      - test-service-update:
-          name: codedeploy_fargate_test-update-service-command
-          filters: *filters
-          requires:
-            - codedeploy_fargate_set-up-test-env
-          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
-          family-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-          service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-          docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com"
-          docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
-          role-arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
-          skip-service-update: true
-          context: [CPE-OIDC]
-      - aws-ecs/deploy-service-update:
-          name: codedeploy_fargate_test-update-service-job
-          docker-image-for-job: cimg/python:3.10.4
-          filters: *filters
-          requires:
-            - codedeploy_fargate_test-update-service-command
-          aws-region: AWS_REGION
-          family: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-          cluster: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
-          container-image-name-updates: "container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,image-and-tag=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
-          container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=BUILD_DATE,value=$(date)'
-          deployment-controller: "CODE_DEPLOY"
-          codedeploy-application-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeployapp"
-          codedeploy-deployment-group-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
-          codedeploy-load-balanced-container-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-          codedeploy-load-balanced-container-port: 8080
-          codedeploy-capacity-provider-name: "FARGATE"
-          codedeploy-capacity-provider-base: "1"
-          codedeploy-capacity-provider-weight: "2"
-          verify-revision-is-deployed: false
-          context: [CPE-OIDC]
-          role-arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
-          post-steps:
-            - wait-for-codedeploy-deployment:
-                application-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeployapp"
-                deployment-group-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
-            - test-deployment:
-                service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-                cluster: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
-                delete-load-balancer: false
-      - aws-ecs/deploy-service-update:
-          name: codedeploy_fargate_test-update-and-wait-service-job
-          docker-image-for-job: cimg/python:3.10.4
-          context: [CPE-OIDC]
-          role-arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
-          filters: *filters
-          requires:
-            - codedeploy_fargate_test-update-service-job
-          aws-region: AWS_REGION
-          family: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-          cluster: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
-          container-image-name-updates: "container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,image-and-tag=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
-          container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=BUILD_DATE,value=$(date)'
-          deployment-controller: "CODE_DEPLOY"
-          codedeploy-application-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeployapp"
-          codedeploy-deployment-group-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
-          codedeploy-load-balanced-container-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-          codedeploy-load-balanced-container-port: 8080
-          verify-revision-is-deployed: true
-          verification-timeout: "12m"
-          post-steps:
-            - test-deployment:
-                service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-                cluster: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
-                delete-load-balancer: true
-            - delete-service:
-                service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-                cluster: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
-      - tear-down-test-env:
-          name: codedeploy_fargate_tear-down-test-env
-          requires:
-            - codedeploy_fargate_test-update-and-wait-service-job
-          terraform-image: "hashicorp/terraform:1.1.9"
-          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
-          terraform-config-dir: "tests/terraform_setup/fargate_codedeploy"
-          context: [CPE-OIDC]
-          role-arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
-          filters: *filters
-      - orb-tools/pack:
-          filters: *filters
-      - orb-tools/publish:
-          orb-name: circleci/aws-ecs
-          vcs-type: << pipeline.project.type >>
-          pub-type: production
-          requires:
-            - orb-tools/pack
-            - ec2_tear-down-test-env
-            - fargate_tear-down-test-env  
-            - codedeploy_fargate_tear-down-test-env
-            - integration-test-ecs-cli-install
-          context: orb-publisher
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
+      # - build-test-app:
+      #     name: codedeploy_fargate_build-test-app
+      #     docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+      #     docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
+      #     context: [CPE-OIDC]
+      #     filters: *filters
+      # - set-up-test-env:
+      #     name: codedeploy_fargate_set-up-test-env
+      #     filters: *filters
+      #     requires:
+      #       - codedeploy_fargate_build-test-app
+      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
+      #     terraform-config-dir: "tests/terraform_setup/fargate_codedeploy"
+      #     context: [CPE-OIDC]
+      #     role-arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST" 
+      # - test-service-update:
+      #     name: codedeploy_fargate_test-update-service-command
+      #     filters: *filters
+      #     requires:
+      #       - codedeploy_fargate_set-up-test-env
+      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
+      #     family-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+      #     service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+      #     docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+      #     docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
+      #     role-arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+      #     skip-service-update: true
+      #     context: [CPE-OIDC]
+      # - aws-ecs/deploy-service-update:
+      #     name: codedeploy_fargate_test-update-service-job
+      #     auth:
+      #       - aws-cli/setup:
+      #           role-arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+      #           profile-name: "ECS_TEST_PROFILE"
+      #     profile-name: "ECS_TEST_PROFILE"
+      #     docker-image-for-job: cimg/python:3.10.4
+      #     filters: *filters
+      #     requires:
+      #       - codedeploy_fargate_test-update-service-command
+      #     family: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+      #     cluster: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+      #     container-image-name-updates: "container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,image-and-tag=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
+      #     container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=BUILD_DATE,value=$(date)'
+      #     deployment-controller: "CODE_DEPLOY"
+      #     codedeploy-application-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeployapp"
+      #     codedeploy-deployment-group-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
+      #     codedeploy-load-balanced-container-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+      #     codedeploy-load-balanced-container-port: 8080
+      #     codedeploy-capacity-provider-name: "FARGATE"
+      #     codedeploy-capacity-provider-base: "1"
+      #     codedeploy-capacity-provider-weight: "2"
+      #     verify-revision-is-deployed: false
+      #     context: [CPE-OIDC]
+      #     post-steps:
+      #       - wait-for-codedeploy-deployment:
+      #           application-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeployapp"
+      #           deployment-group-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
+      #       - test-deployment:
+      #           service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+      #           cluster: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+      #           delete-load-balancer: false
+      # - aws-ecs/deploy-service-update:
+      #     name: codedeploy_fargate_test-update-and-wait-service-job
+      #     auth:
+      #       - aws-cli/setup:
+      #           role-arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+      #           profile-name: "ECS_TEST_PROFILE"
+      #     profile-name: "ECS_TEST_PROFILE"        
+      #     docker-image-for-job: cimg/python:3.10.4
+      #     context: [CPE-OIDC]
+      #     filters: *filters
+      #     requires:
+      #       - codedeploy_fargate_test-update-service-job
+      #     family: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+      #     cluster: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+      #     container-image-name-updates: "container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,image-and-tag=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
+      #     container-env-var-updates: 'container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=BUILD_DATE,value=$(date)'
+      #     deployment-controller: "CODE_DEPLOY"
+      #     codedeploy-application-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeployapp"
+      #     codedeploy-deployment-group-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
+      #     codedeploy-load-balanced-container-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+      #     codedeploy-load-balanced-container-port: 8080
+      #     verify-revision-is-deployed: true
+      #     verification-timeout: "12m"
+      #     post-steps:
+      #       - test-deployment:
+      #           service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+      #           cluster: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+      #           delete-load-balancer: true
+      #       - delete-service:
+      #           service-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+      #           cluster: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+      # - tear-down-test-env:
+      #     name: codedeploy_fargate_tear-down-test-env
+      #     requires:
+      #       - codedeploy_fargate_test-update-and-wait-service-job
+      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
+      #     terraform-config-dir: "tests/terraform_setup/fargate_codedeploy"
+      #     context: [CPE-OIDC]
+      #     role-arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+      #     filters: *filters
+      # - orb-tools/pack:
+      #     filters: *filters
+      # - orb-tools/publish:
+      #     orb-name: circleci/aws-ecs
+      #     vcs-type: << pipeline.project.type >>
+      #     pub-type: production
+      #     requires:
+      #       - orb-tools/pack
+      #       - ec2_tear-down-test-env
+      #       - fargate_tear-down-test-env  
+      #       - codedeploy_fargate_tear-down-test-env
+      #       - integration-test-ecs-cli-install
+      #     context: orb-publisher
+      #     filters:
+      #       branches:
+      #         ignore: /.*/
+      #       tags:
+      #         only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
 commands:
   wait-for-codedeploy-deployment:
     description: "Wait for the CodeDeploy deployment to be successful"

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -6,6 +6,3 @@ description: >
 display:
   home_url: "https://aws.amazon.com/ecs/"
   source_url: "https://github.com/CircleCI-Public/aws-ecs-orb"
-
-orbs:
-  aws-cli: circleci/aws-cli@3.1

--- a/src/examples/deploy-ecs-scheduled-task.yml
+++ b/src/examples/deploy-ecs-scheduled-task.yml
@@ -5,7 +5,7 @@ usage:
   version: 2.1
   orbs:
     aws-cli: circleci/aws-cli@3.1
-    aws-ecs: circleci/aws-ecs@3.2
+    aws-ecs: circleci/aws-ecs@4.0
   jobs:
     deploy-scheduled-task:
       docker:

--- a/src/examples/deploy-service-update.yml
+++ b/src/examples/deploy-service-update.yml
@@ -30,7 +30,7 @@ usage:
                   profile: "OIDC-USER"
                   role-arn: "arn:aws:iam::123456789012:role/VALID_OIDC_ECS_ROLE"
             # Must use same profile configured in aws-cli/setup command
-            profile: "OIDC-USER"        
+            profile: "OIDC-USER"
             requires:
               - aws-ecr/build-and-push-image
             family: '${MY_APP_PREFIX}-service'

--- a/src/examples/deploy-service-update.yml
+++ b/src/examples/deploy-service-update.yml
@@ -1,18 +1,36 @@
-description: Update an ECS service.
+description: |
+  Update an ECS service using OIDC for authentication.
+  Import the aws-cli orb and authenticate using the aws-cli/setup command with a valid role-arn for OIDC authentication.
 usage:
   version: 2.1
   orbs:
-    aws-ecr: circleci/aws-ecr@8.1
-    aws-ecs: circleci/aws-ecs@3.2
+    aws-ecr: circleci/aws-ecr@9.0
+    aws-ecs: circleci/aws-ecs@4.0
+    # Importing aws-cli orb is required for authentication
+    aws-cli: circleci/aws-cli@3.1
   workflows:
     build-and-deploy:
       jobs:
         - aws-ecr/build-and-push-image:
+            auth:
+              # Add authentication step with OIDC using aws-cli/setup command
+              - aws-cli/setup:
+                  profile: "OIDC-USER"
+                  role-arn: "arn:aws:iam::123456789012:role/VALID_OIDC_ECR_ROLE"
+            # Must use same profile configured in aws-cli/setup command
+            profile: "OIDC-USER"
             registry-id: AWS_ECR_REGISTRY_ID
             repo: '${MY_APP_PREFIX}'
             region: AWS_REGION
             tag: '${CIRCLE_SHA1}'
         - aws-ecs/deploy-service-update:
+            auth:
+              # Add authentication step with OIDC using aws-cli/setup command
+              - aws-cli/setup:
+                  profile: "OIDC-USER"
+                  role-arn: "arn:aws:iam::123456789012:role/VALID_OIDC_ECS_ROLE"
+            # Must use same profile configured in aws-cli/setup command
+            profile: "OIDC-USER"        
             requires:
               - aws-ecr/build-and-push-image
             family: '${MY_APP_PREFIX}-service'

--- a/src/examples/run-task-ec2.yml
+++ b/src/examples/run-task-ec2.yml
@@ -2,12 +2,16 @@ description: Start the run of an ECS task on EC2.
 usage:
   version: 2.1
   orbs:
-    aws-ecs: circleci/aws-ecs@3.2
+    aws-ecs: circleci/aws-ecs@4.0
+    aws-cli: circleci/aws-cli@3.1
   jobs:
     run-task:
       docker:
         - image: cimg/python:3.10
       steps:
+        - aws-cli/setup:
+            profile: "OIDC-USER"
+            role-arn: "arn:aws:iam::123456789012:role/VALID_OIDC_ECS_ROLE"
         - aws-ecs/run-task:
             cluster: cluster1
             task-definition: myapp

--- a/src/examples/run-task-fargate-spot.yml
+++ b/src/examples/run-task-fargate-spot.yml
@@ -13,7 +13,7 @@ usage:
       steps:
         - aws-cli/setup:
             profile: "OIDC-USER"
-            role-arn: "arn:aws:iam::123456789012:role/VALID_OIDC_ECS_ROLE"      
+            role-arn: "arn:aws:iam::123456789012:role/VALID_OIDC_ECS_ROLE"
         - aws-ecs/run-task:
             cluster: $CLUSTER_NAME
             capacity-provider-strategy: capacityProvider=FARGATE,weight=1 capacityProvider=FARGATE_SPOT,weight=1

--- a/src/examples/run-task-fargate-spot.yml
+++ b/src/examples/run-task-fargate-spot.yml
@@ -5,12 +5,15 @@ description: >
 usage:
   version: 2.1
   orbs:
-    aws-ecs: circleci/aws-ecs@3.2
+    aws-ecs: circleci/aws-ecs@4.0
   jobs:
     run-task:
       docker:
         - image: cimg/python:3.10
       steps:
+        - aws-cli/setup:
+            profile: "OIDC-USER"
+            role-arn: "arn:aws:iam::123456789012:role/VALID_OIDC_ECS_ROLE"      
         - aws-ecs/run-task:
             cluster: $CLUSTER_NAME
             capacity-provider-strategy: capacityProvider=FARGATE,weight=1 capacityProvider=FARGATE_SPOT,weight=1

--- a/src/examples/run-task-fargate.yml
+++ b/src/examples/run-task-fargate.yml
@@ -2,12 +2,15 @@ description: Start the run of an ECS task on Fargate.
 usage:
   version: 2.1
   orbs:
-    aws-ecs: circleci/aws-ecs@3.2
+    aws-ecs: circleci/aws-ecs@4.0
   jobs:
     run-task:
       docker:
         - image: cimg/python:3.10
       steps:
+        - aws-cli/setup:
+            profile: "OIDC-USER"
+            role-arn: "arn:aws:iam::123456789012:role/VALID_OIDC_ECS_ROLE"      
         - aws-ecs/run-task:
             cluster: cluster1
             task-definition: myapp

--- a/src/examples/run-task-fargate.yml
+++ b/src/examples/run-task-fargate.yml
@@ -10,7 +10,7 @@ usage:
       steps:
         - aws-cli/setup:
             profile: "OIDC-USER"
-            role-arn: "arn:aws:iam::123456789012:role/VALID_OIDC_ECS_ROLE"      
+            role-arn: "arn:aws:iam::123456789012:role/VALID_OIDC_ECS_ROLE"
         - aws-ecs/run-task:
             cluster: cluster1
             task-definition: myapp

--- a/src/examples/update-service.yml
+++ b/src/examples/update-service.yml
@@ -5,7 +5,7 @@ usage:
   version: 2.1
   orbs:
     aws-cli: circleci/aws-cli@3.1
-    aws-ecs: circleci/aws-ecs@3.2
+    aws-ecs: circleci/aws-ecs@4.0
   jobs:
     update-tag:
       docker:

--- a/src/examples/update-task-definition-from-json.yml
+++ b/src/examples/update-task-definition-from-json.yml
@@ -3,7 +3,7 @@ usage:
   version: 2.1
   orbs:
     aws-cli: circleci/aws-cli@3.1
-    aws-ecs: circleci/aws-ecs@3.2
+    aws-ecs: circleci/aws-ecs@4.0
   jobs:
     update-tag:
       docker:

--- a/src/examples/verify-revision-deplopyment.yml
+++ b/src/examples/verify-revision-deplopyment.yml
@@ -3,7 +3,7 @@ usage:
   version: 2.1
   orbs:
     aws-cli: circleci/aws-cli@3.1
-    aws-ecs: circleci/aws-ecs@3.2
+    aws-ecs: circleci/aws-ecs@4.0
   jobs:
     verify-deployment:
       docker:

--- a/src/jobs/deploy-service-update.yml
+++ b/src/jobs/deploy-service-update.yml
@@ -8,38 +8,14 @@ parameters:
     description: The docker image to be used for running this job on CircleCI.
     type: string
     default: 'cimg/python:3.10.4'
-  aws-access-key-id:
-    description: |
-      AWS access key id for IAM role. Set this to the name of the environment variable you will use to hold this value, i.e. AWS_ACCESS_KEY_ID.
-    type: env_var_name
-    default: AWS_ACCESS_KEY_ID
-  aws-secret-access-key:
-    description: |
-      AWS secret key for IAM role. Set this to the name of the environment variable you will use to hold this value, i.e. AWS_SECRET_ACCESS_KEY.
-    type: env_var_name
-    default: AWS_SECRET_ACCESS_KEY
   aws-region:
     description: AWS region to operate in. Set this to the name of the environment variable you will use to hold this value, i.e. AWS_DEFAULT_REGION.
     type: env_var_name
-    default: AWS_REGION
+    default: AWS_DEFAULT_REGION
   profile-name:
     description: AWS profile name to be configured.
     type: string
-    default: ''
-  role-arn:
-    description: |
-      The Amazon Resource Name (ARN) of the role that the caller is assuming.
-      Role ARN must be configured for web identity.
-    type: string
-    default: ""
-  role-session-name:
-    description: An identifier for the assumed role session. Environment varaibles will be evaluated.
-    type: string
-    default: ${CIRCLE_JOB}
-  session-duration:
-    description: The duration of the session in seconds
-    type: string
-    default: "3600"
+    default: "default"
   family:
     description: Name of the task definition's family.
     type: string
@@ -247,25 +223,14 @@ parameters:
       If not specified, the value configured in the deployment group is used as the default.
     type: string
     default: ''
+  auth:
+    description: |
+      The authentication method used to access your AWS account. Import the aws-cli orb in your config and
+      provide the aws-cli/setup command to authenticate with your preferred method. View examples for more information.
+    type: steps
 
 steps:
-  - when:
-      condition: <<parameters.role-arn>>
-      steps:
-        - aws-cli/setup:
-            role-arn: <<parameters.role-arn>>
-            profile-name: <<parameters.profile-name>>
-            session-duration: <<parameters.session-duration>>
-            aws-region: <<parameters.aws-region>>
-            role-session-name: <<parameters.role-session-name>>
-  - unless:
-      condition: <<parameters.role-arn>>
-      steps:
-        - aws-cli/setup:
-            aws-access-key-id: << parameters.aws-access-key-id >>
-            aws-secret-access-key: << parameters.aws-secret-access-key >>
-            aws-region: << parameters.aws-region >>
-            profile-name: << parameters.profile-name >>
+  - steps: << parameters.auth >>
   - update-service:
       family: << parameters.family >>
       cluster: << parameters.cluster >>

--- a/src/jobs/run-task.yml
+++ b/src/jobs/run-task.yml
@@ -8,38 +8,14 @@ parameters:
     description: The docker image to be used for running this job on CircleCI.
     type: string
     default: 'cimg/python:3.10.4'
-  aws-access-key-id:
-    description: |
-      AWS access key id for IAM role. Set this to the name of the environment variable you will use to hold this value, i.e. AWS_ACCESS_KEY_ID.
-    type: env_var_name
-    default: AWS_ACCESS_KEY_ID
-  aws-secret-access-key:
-    description: |
-      AWS secret key for IAM role. Set this to the name of the environment variable you will use to hold this value, i.e. AWS_SECRET_ACCESS_KEY.
-    type: env_var_name
-    default: AWS_SECRET_ACCESS_KEY
   aws-region:
     description: AWS region to operate in. Set this to the name of the environment variable you will use to hold this value, i.e. AWS_DEFAULT_REGION.
     type: env_var_name
-    default: AWS_REGION
+    default: AWS_DEFAULT_REGION
   profile-name:
     description: AWS profile name to be configured.
     type: string
-    default: ''
-  role-arn:
-    description: |
-      The Amazon Resource Name (ARN) of the role that the caller is assuming.
-      Role ARN must be configured for web identity.
-    type: string
-    default: ""
-  role-session-name:
-    description: An identifier for the assumed role session
-    type: string
-    default: ${CIRCLE_JOB}
-  session-duration:
-    description: The duration of the session in seconds
-    type: string
-    default: "3600"
+    default: "default"
   cluster:
     description: The name or ARN of the cluster on which to run the task.
     type: string
@@ -168,24 +144,13 @@ parameters:
           Specifies a local json file to save the output logs from the aws ecs run-task command. Use tools like JQ to read and parse this information such as "task-arns" and "task-ids"
     type: string
     default: ''
+  auth:
+    description: |
+      The authentication method used to access your AWS account. Import the aws-cli orb in your config and
+      provide the aws-cli/setup command to authenticate with your preferred method. View examples for more information.
+    type: steps
 steps:
-  - when:
-      condition: <<parameters.role-arn>>
-      steps:
-        - aws-cli/setup:
-            role-arn: <<parameters.role-arn>>
-            profile-name: <<parameters.profile-name>>
-            session-duration: <<parameters.session-duration>>
-            aws-region: <<parameters.aws-region>>
-            role-session-name: <<parameters.role-session-name>>
-  - unless:
-      condition: <<parameters.role-arn>>
-      steps:
-        - aws-cli/setup:
-            aws-access-key-id: << parameters.aws-access-key-id >>
-            aws-secret-access-key: << parameters.aws-secret-access-key >>
-            aws-region: << parameters.aws-region >>
-            profile-name: << parameters.profile-name >>
+  - steps: << parameters.auth >>
   - run-task:
       cluster: << parameters.cluster >>
       task-definition: << parameters.task-definition >>

--- a/src/jobs/update-task-definition-from-json.yml
+++ b/src/jobs/update-task-definition-from-json.yml
@@ -7,38 +7,14 @@ parameters:
     description: The docker image to be used for running this job on CircleCI.
     type: string
     default: 'cimg/python:3.10.4'
-  aws-access-key-id:
-    description: |
-      AWS access key id for IAM role. Set this to the name of the environment variable you will use to hold this value, i.e. AWS_ACCESS_KEY_ID.
-    type: env_var_name
-    default: AWS_ACCESS_KEY_ID
-  aws-secret-access-key:
-    description: |
-      AWS secret key for IAM role. Set this to the name of the environment variable you will use to hold this value, i.e. AWS_SECRET_ACCESS_KEY.
-    type: env_var_name
-    default: AWS_SECRET_ACCESS_KEY
   aws-region:
     description: AWS region to operate in. Set this to the name of the environment variable you will use to hold this value, i.e. AWS_DEFAULT_REGION.
     type: env_var_name
-    default: AWS_REGION
-  role-arn:
-    description: |
-      The Amazon Resource Name (ARN) of the role that the caller is assuming.
-      Role ARN must be configured for web identity.
-    type: string
-    default: ""
-  role-session-name:
-    description: An identifier for the assumed role session
-    type: string
-    default: ${CIRCLE_JOB}
-  session-duration:
-    description: The duration of the session in seconds
-    type: string
-    default: "3600"
+    default: AWS_DEFAULT_REGION
   profile-name:
     description: AWS profile name to be configured.
     type: string
-    default: ''
+    default: "default"
   task-definition-json:
     description: |
       Location of your .json task definition file (relative or absolute).
@@ -51,24 +27,13 @@ parameters:
   rule-name:
     description: The name of the scheduled task's rule to update. Must be a valid ECS Rule.
     type: string
+  auth:
+    description: |
+      The authentication method used to access your AWS account. Import the aws-cli orb in your config and
+      provide the aws-cli/setup command to authenticate with your preferred method. View examples for more information.
+    type: steps
 steps:
-  - when:
-      condition: <<parameters.role-arn>>
-      steps:
-        - aws-cli/setup:
-            role-arn: <<parameters.role-arn>>
-            profile-name: <<parameters.profile-name>>
-            session-duration: <<parameters.session-duration>>
-            aws-region: <<parameters.aws-region>>
-            role-session-name: <<parameters.role-session-name>>
-  - unless:
-      condition: <<parameters.role-arn>>
-      steps:
-        - aws-cli/setup:
-            aws-access-key-id: << parameters.aws-access-key-id >>
-            aws-secret-access-key: << parameters.aws-secret-access-key >>
-            aws-region: << parameters.aws-region >>
-            profile-name: << parameters.profile-name >>
+  - steps: << parameters.auth >>
   - update-task-definition-from-json:
       task-definition-json: << parameters.task-definition-json >>
       profile-name: << parameters.profile-name >>

--- a/src/jobs/update-task-definition.yml
+++ b/src/jobs/update-task-definition.yml
@@ -8,38 +8,14 @@ parameters:
     description: The docker image to be used for running this job on CircleCI.
     type: string
     default: 'cimg/python:3.10.4'
-  aws-access-key-id:
-    description: |
-      AWS access key id for IAM role. Set this to the name of the environment variable you will use to hold this value, i.e. AWS_ACCESS_KEY_ID.
-    type: env_var_name
-    default: AWS_ACCESS_KEY_ID
-  aws-secret-access-key:
-    description: |
-      AWS secret key for IAM role. Set this to the name of the environment variable you will use to hold this value, i.e. AWS_SECRET_ACCESS_KEY.
-    type: env_var_name
-    default: AWS_SECRET_ACCESS_KEY
   aws-region:
     description: AWS region to operate in. Set this to the name of the environment variable you will use to hold this value, i.e. AWS_DEFAULT_REGION.
     type: env_var_name
-    default: AWS_REGION
-  role-arn:
-    description: |
-      The Amazon Resource Name (ARN) of the role that the caller is assuming.
-      Role ARN must be configured for web identity.
-    type: string
-    default: ""
-  role-session-name:
-    description: An identifier for the assumed role session
-    type: string
-    default: ${CIRCLE_JOB}
-  session-duration:
-    description: The duration of the session in seconds
-    type: string
-    default: "3600"
+    default: AWS_DEFAULT_REGION
   profile-name:
     description: AWS profile name to be configured.
     type: string
-    default: ''
+    default: "default"
   family:
     description: Name of the task definition's family.
     type: string
@@ -111,24 +87,13 @@ parameters:
   rule-name:
     description: The name of the scheduled task's rule to update. Must be a valid ECS Rule.
     type: string
+  auth:
+    description: |
+      The authentication method used to access your AWS account. Import the aws-cli orb in your config and
+      provide the aws-cli/setup command to authenticate with your preferred method. View examples for more information.
+    type: steps
 steps:
-  - when:
-      condition: <<parameters.role-arn>>
-      steps:
-        - aws-cli/setup:
-            role-arn: <<parameters.role-arn>>
-            profile-name: <<parameters.profile-name>>
-            session-duration: <<parameters.session-duration>>
-            aws-region: <<parameters.aws-region>>
-            role-session-name: <<parameters.role-session-name>>
-  - unless:
-      condition: <<parameters.role-arn>>
-      steps:
-        - aws-cli/setup:
-            aws-access-key-id: << parameters.aws-access-key-id >>
-            aws-secret-access-key: << parameters.aws-secret-access-key >>
-            aws-region: << parameters.aws-region >>
-            profile-name: << parameters.profile-name >>
+  - steps: << parameters.auth >>
   - update-task-definition:
       family: << parameters.family >>
       container-image-name-updates: << parameters.container-image-name-updates >>

--- a/src/scripts/run-task.sh
+++ b/src/scripts/run-task.sh
@@ -91,7 +91,11 @@ set -- "$@" --cluster "$ECS_PARAM_CLUSTER_NAME"
 
 
 if [ -n "${ECS_PARAM_RUN_TASK_OUTPUT}" ]; then
+    set -x
     aws ecs run-task "$@" | tee "${ECS_PARAM_RUN_TASK_OUTPUT}"
-else    
+    set +x
+else
+    set -x    
     aws ecs run-task "$@"
+    set +x
 fi

--- a/tests/terraform_setup/ec2/cloudformation-templates/public-service.yml
+++ b/tests/terraform_setup/ec2/cloudformation-templates/public-service.yml
@@ -57,7 +57,10 @@ Conditions:
   HasCustomRole: !Not [ !Equals [!Ref 'Role', ''] ]
 
 Resources:
-
+  MyLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: ecs-orb-logs
   # The task definition. This is a simple metadata description of what
   # container to run, and what resource requirements it has.
   TaskDefinition:
@@ -82,13 +85,19 @@ Resources:
         - Name: !Ref 'ServiceName'
           Cpu: 512
           Memory: 1024
-          Image: !Ref 'ImageUrl'
+          Image: nginx:latest
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: ecs-orb-logs
+              awslogs-region: us-west-2
+              awslogs-stream-prefix: ecs-orb-ec2-stream
           PortMappings:
             - ContainerPort: !Ref 'ContainerPort'
         - Name: DummyContainer
           Cpu: 512
           Memory: 1024
-          Image: nginx:latest
+          Image: nginx:latest    
           Environment:
             - Name: DUMMY_VAR_1
               Value: 'a'
@@ -96,7 +105,12 @@ Resources:
               Value: "b's knees"
             - Name: DUMMY_VAR_3
               Value: "c testing'''now"
-
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: ecs-orb-logs
+              awslogs-region: us-west-2
+              awslogs-stream-prefix: ecs-orb-ec2-stream
   # The service. The service is a resource which allows you to run multiple
   # copies of a type of task, and gather up their logs and metrics, as well
   # as monitor the number of running tasks and replace any that have crashed

--- a/tests/terraform_setup/ec2/terraform.tf
+++ b/tests/terraform_setup/ec2/terraform.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 4.22.0"
+      version = "~> 4.63.0"
     }
   }
   backend "s3" {
@@ -69,7 +69,7 @@ resource "aws_cloudformation_stack" "ecs_service" {
   parameters = {
     TaskCpu       = 1024
     TaskMemory    = 2048
-    ContainerPort = 8080
+    ContainerPort = 80
     StackName     = local.aws_vpc_stack_name
     ServiceName   = local.aws_ecs_service_name
     FamilyName    = local.aws_ecs_family_name

--- a/tests/terraform_setup/fargate/terraform.tf
+++ b/tests/terraform_setup/fargate/terraform.tf
@@ -66,7 +66,7 @@ resource "aws_cloudformation_stack" "ecs_service" {
 
   parameters = {
     ContainerMemory = 1024
-    ContainerPort   = 8080
+    ContainerPort   = 80
     StackName       = local.aws_vpc_stack_name
     ServiceName     = local.aws_ecs_service_name
     # Note: Since ImageUrl parameter is not specified, the Service

--- a/tests/terraform_setup/fargate_codedeploy/variables.tf
+++ b/tests/terraform_setup/fargate_codedeploy/variables.tf
@@ -18,17 +18,17 @@ variable "health_check_path" {
 }
 
 variable "container_port" {
-  default = "8080"
-}
-
-variable "host_port" {
-  default = "8080"
-}
-
-variable "app_port" {
   default = "80"
 }
 
-variable "app_port_green" {
+variable "host_port" {
+  default = "80"
+}
+
+variable "app_port" {
   default = "8080"
+}
+
+variable "app_port_green" {
+  default = "80"
 }

--- a/tests/test_app/Dockerfile
+++ b/tests/test_app/Dockerfile
@@ -1,6 +1,6 @@
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 
 COPY ./demo-app /opt/
-EXPOSE 8080
+EXPOSE 80
 
 ENTRYPOINT ["/opt/demo-app"]

--- a/tests/test_app/src/main.go
+++ b/tests/test_app/src/main.go
@@ -14,5 +14,5 @@ func mainHandler() http.HandlerFunc {
 
 func main() {
 	http.HandleFunc("/", mainHandler())
-	http.ListenAndServe(":8080", nil)
+	http.ListenAndServe(":80", nil)
 }


### PR DESCRIPTION
This `PR` adds the `auth` parameter to all `ecs` jobs, requiring users to customize their authentication method by importing the `aws-cli` orb and using the `aws-cli/setup` command to authenticate using static AWS keys or a valid `role-arn` for OIDC.