### PR TITLE
chore: fix parameter typos in examples

### DIFF
--- a/src/examples/deploy_ecs_scheduled_task.yml
+++ b/src/examples/deploy_ecs_scheduled_task.yml
@@ -16,8 +16,8 @@ usage:
             role_arn: "arn:aws:iam::123456789012:role/OIDC_ARN"
             region: AWS_REGION
             profile_name: "OIDC-PROFILE"
-            session-duration: 3600
-            role-session-name: "example-session-name"
+            session_duration: "3600"
+            role_session_name: "example-session-name"
         - aws-ecs/update_task_definition_from_json:
             task_definition_json: my-app-definition.json
         - aws-ecs/deploy_ecs_scheduled_task:

--- a/src/examples/deploy_service_update.yml
+++ b/src/examples/deploy_service_update.yml
@@ -19,7 +19,7 @@ usage:
                   role_arn: "arn:aws:iam::123456789012:role/VALID_OIDC_ECR_ROLE"
             # Must use same profile configured in aws-cli/setup command
             profile: "OIDC-USER"
-            registry-id: AWS_ECR_REGISTRY_ID
+            registry_id: ${AWS_ECR_REGISTRY_ID}
             repo: '${MY_APP_PREFIX}'
             region: AWS_REGION
             tag: '${CIRCLE_SHA1}'

--- a/src/examples/update_service.yml
+++ b/src/examples/update_service.yml
@@ -16,8 +16,8 @@ usage:
             role_arn: "arn:aws:iam::123456789012:role/OIDC_ARN"
             region: AWS_REGION
             profile_name: "OIDC-PROFILE"
-            session-duration: 3600
-            role-session-name: "example-session-name"
+            session_duration: "3600"
+            role_session_name: "example-session-name"
         - aws-ecs/update_service:
             family: '${MY_APP_PREFIX}-service'
             cluster: '${MY_APP_PREFIX}-cluster'

--- a/src/examples/update_task_definition_from_json.yml
+++ b/src/examples/update_task_definition_from_json.yml
@@ -14,8 +14,8 @@ usage:
             role_arn: "arn:aws:iam::123456789012:role/OIDC_ARN"
             region: AWS_REGION
             profile_name: "OIDC-PROFILE"
-            session-duration: 3600
-            role-session-name: "example-session-name"
+            session_duration: "3600"
+            role_session_name: "example-session-name"
         - aws-ecs/update_task_definition_from_json:
             task_definition_json: my-app-definition.json
   workflows:

--- a/src/examples/verify_revision_deployment.yml
+++ b/src/examples/verify_revision_deployment.yml
@@ -14,8 +14,8 @@ usage:
             role_arn: "arn:aws:iam::123456789012:role/OIDC_ARN"
             region: AWS_REGION
             profile_name: "OIDC-PROFILE"
-            session-duration: 3600
-            role-session-name: "example-session-name"
+            session_duration: "3600"
+            role_session_name: "example-session-name"
         - run:
             name: Get last task definition
             command: >


### PR DESCRIPTION
This `PR` corrects the typos found in the usage examples. It also changes all parameters to snake case