### PR TITLE
feat: Adding enable-execute-command option to run_task

### DIFF
--- a/src/commands/run_task.yml
+++ b/src/commands/run_task.yml
@@ -102,6 +102,12 @@ parameters:
       "Specifies whether to enable Amazon ECS managed tags for the task."
     type: boolean
     default: false
+  enable_execute_command:
+    description: |
+      Determines whether to use the execute command functionality for the containers in this task. If true,
+      this enables execute command functionality on all containers in the task.
+    type: boolean
+    default: false
   propagate_tags:
     description: |
       Specifies whether to propagate the tags from the task definition to
@@ -139,6 +145,7 @@ steps:
         ORB_STR_OVERRIDES: <<parameters.overrides>>
         ORB_STR_TAGS: <<parameters.tags>>
         ORB_BOOL_ENABLE_ECS_MANAGED_TAGS: <<parameters.enable_ecs_managed_tags>>
+        ORB_BOOL_ENABLE_EXECUTE_COMMAND: <<parameters.enable_execute_command>>
         ORB_BOOL_PROPAGATE_TAGS: <<parameters.propagate_tags>>
         ORB_STR_CD_CAPACITY_PROVIDER_STRATEGY: <<parameters.capacity_provider_strategy>>
         ORB_STR_PROFILE_NAME: <<parameters.profile_name>>

--- a/src/jobs/run_task.yml
+++ b/src/jobs/run_task.yml
@@ -119,6 +119,12 @@ parameters:
       "Specifies whether to enable Amazon ECS managed tags for the task."
     type: boolean
     default: false
+  enable_execute_command:
+    description: |
+      Determines whether to use the execute command functionality for the containers in this task. If true,
+      this enables execute command functionality on all containers in the task.
+    type: boolean
+    default: false
   propagate_tags:
     description: |
       "Specifies whether to propagate the tags from the task definition to
@@ -167,6 +173,7 @@ steps:
       overrides: << parameters.overrides >>
       tags: << parameters.tags >>
       enable_ecs_managed_tags: << parameters.enable_ecs_managed_tags >>
+      enable_execute_command: << parameters.enable_execute_command>>
       propagate_tags: << parameters.propagate_tags >>
       capacity_provider_strategy: << parameters.capacity_provider_strategy >>
       profile_name: << parameters.profile_name >>

--- a/src/scripts/run_task.sh
+++ b/src/scripts/run_task.sh
@@ -51,6 +51,10 @@ if [ "$ORB_BOOL_ENABLE_ECS_MANAGED_TAGS" == "1" ]; then
     echo "Setting --enable-ecs-managed-tags"
     set -- "$@" --enable-ecs-managed-tags
 fi
+if [ "$ORB_BOOL_ENABLE_EXECUTE_COMMAND" == "1" ]; then
+    echo "Setting --enable-execute-command"
+    set -- "$@" --enable-execute-command
+fi
 if [ "$ORB_BOOL_PROPAGATE_TAGS" == "1" ]; then
     echo "Setting --propagate-tags"
     set -- "$@" --propagate-tags "TASK_DEFINITION"


### PR DESCRIPTION
This is to add support for the `--enable-execute-command` option for the `run_task` command/job.  This can be useful for debugging when running tasks in a dev/staging/integration environment.  Also to make `run_task` more feature complete.