### PR TITLE
added region while describing the task definition using ecs

### DIFF
--- a/src/commands/update_service.yml
+++ b/src/commands/update_service.yml
@@ -206,7 +206,8 @@ steps:
                 --task-definition << parameters.family >> \
                 --output text \
                 --query 'taskDefinition.taskDefinitionArn' \
-                --profile=<< parameters.profile_name >>)
+                --profile << parameters.profile_name >>
+                --region ${AWS_DEFAULT_REGION})
               echo "export CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN='${TASK_DEFINITION_ARN}'" >> $BASH_ENV
   - when:
       condition: << parameters.task_definition_tags >>

--- a/src/commands/update_service.yml
+++ b/src/commands/update_service.yml
@@ -206,7 +206,7 @@ steps:
                 --task-definition << parameters.family >> \
                 --output text \
                 --query 'taskDefinition.taskDefinitionArn' \
-                --profile << parameters.profile_name >>
+                --profile << parameters.profile_name >> \
                 --region ${AWS_DEFAULT_REGION})
               echo "export CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN='${TASK_DEFINITION_ARN}'" >> $BASH_ENV
   - when:

--- a/src/examples/verify_revision_deployment.yml
+++ b/src/examples/verify_revision_deployment.yml
@@ -23,7 +23,7 @@ usage:
                   --task_definition ${MY_APP_PREFIX}-service \
                   --output text \
                   --query 'taskDefinition.taskDefinitionArn' \
-                  --profile default
+                  --profile default \
                   --region ${AWS_DEFAULT_REGION})
               echo "export TASK_DEFINITION_ARN='${TASK_DEFINITION_ARN}'" >>
               $BASH_ENV

--- a/src/examples/verify_revision_deployment.yml
+++ b/src/examples/verify_revision_deployment.yml
@@ -23,7 +23,8 @@ usage:
                   --task_definition ${MY_APP_PREFIX}-service \
                   --output text \
                   --query 'taskDefinition.taskDefinitionArn' \
-                  --profile default)
+                  --profile default
+                  --region ${AWS_DEFAULT_REGION})
               echo "export TASK_DEFINITION_ARN='${TASK_DEFINITION_ARN}'" >>
               $BASH_ENV
         - aws-ecs/verify_revision_is_deployed:

--- a/src/scripts/get_prev_task.sh
+++ b/src/scripts/get_prev_task.sh
@@ -17,7 +17,7 @@ else
 fi
 
 # shellcheck disable=SC2034
-PREVIOUS_TASK_DEFINITION="$(aws ecs describe-task-definition --task-definition "${ECS_TASK_DEFINITION_NAME}" --include TAGS --profile "${ORB_STR_PROFILE_NAME}" "$@")"
+PREVIOUS_TASK_DEFINITION="$(aws ecs describe-task-definition --task-definition "${ECS_TASK_DEFINITION_NAME}" --include TAGS --profile "${ORB_STR_PROFILE_NAME}" --region "${AWS_DEFAULT_REGION}" "$@")"
 
 # Prepare script for updating container definitions
 

--- a/src/scripts/verify_revision_is_deployed.sh
+++ b/src/scripts/verify_revision_is_deployed.sh
@@ -27,6 +27,7 @@ do
         --profile "${ORB_STR_PROFILE_NAME}" \
         --cluster "$ORB_STR_CLUSTER_NAME" \
         --services "${ORB_STR_SERVICE_NAME}" \
+        --region "${AWS_DEFAULT_REGION}" \
         --output text \
         --query 'services[0].deployments[].[taskDefinition, status]' \
         "$@")
@@ -34,6 +35,7 @@ do
         --profile "${ORB_STR_PROFILE_NAME}" \
         --cluster "$ORB_STR_CLUSTER_NAME" \
         --services "${ORB_STR_SERVICE_NAME}" \
+        --region "${AWS_DEFAULT_REGION}" \
         --output text \
         --query 'length(services[0].deployments)' \
         "$@")
@@ -41,6 +43,7 @@ do
         --profile "${ORB_STR_PROFILE_NAME}" \
         --cluster "$ORB_STR_CLUSTER_NAME" \
         --services "${ORB_STR_SERVICE_NAME}" \
+        --region "${AWS_DEFAULT_REGION}" \
         --output text \
         --query "services[0].deployments[?taskDefinition==\`$ORB_STR_TASK_DEF_ARN\` && runningCount == desiredCount && (status == \`PRIMARY\` || status == \`ACTIVE\`)][taskDefinition]" \
         "$@")


### PR DESCRIPTION
Change:

Added the `--region` option to the `aws ecs describe-task-definition` command.

Use Case:

I encountered a scenario where I, as an AWS Identity and Access Management (IAM) user, have permissions to operate in different regions. I set my AWS CLI profile region using `aws configure set default.region first-region`. Consequently, any AWS CLI operations I perform are associated with this default region.

Now, let's consider a situation where I need to update an ECS task service in a second region. The catch here is that both regions have a task definition with the same name. Consequently, the AWS CLI would typically default to using the task definition from the first region when updating.

To address this, I added the `--region` option to the `aws ecs describe-task-definition` command. By doing this, I specify the desired region for the operation, ensuring that the correct task definition ARN is retrieved and used. This adjustment has resolved the issue, and I can now work with task definitions from different regions as needed.