### PR TITLE
Re add tests for code deploy

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -639,12 +639,12 @@ workflows:
       # ################
       # FargateSpot
       # ################
-      - test-fargatespot:
-          context: [CPE-OIDC]
-          filters: *filters
-          role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
-          requires:
-            - fargate_set-up-test-env
+      # - test-fargatespot:
+      #     context: [CPE-OIDC]
+      #     filters: *filters
+      #     role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+      #     requires:
+      #       - fargate_set-up-test-env
       #################
       # CodeDeploy
       #################

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -433,209 +433,209 @@ workflows:
       #################
       # Fargate
       #################
-      - tear-down-test-env:
-          name: fargate_tear-down-test-env-initial
-          filters: *filters
-          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
-          terraform-config-dir: "tests/terraform_setup/fargate"
-          context: [CPE-OIDC]
-          role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"      
-      - build-test-app:
-          name: fargate_build-test-app
-          docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
-          docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}:${CIRCLE_SHA1}"
-          context: [CPE-OIDC]
-          requires:
-            - fargate_tear-down-test-env-initial
-          filters: *filters
-      - set-up-test-env:
-          name: fargate_set-up-test-env
-          filters: *filters
-          requires:
-            - fargate_build-test-app
-          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
-          terraform-config-dir: "tests/terraform_setup/fargate"
-          context: [CPE-OIDC]
-          role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
-      - test-service-update:
-          name: fargate_test-update_service-command
-          filters: *filters
-          requires:
-            - fargate_set-up-test-env
-          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
-          family_name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
-          service_name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
-          docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
-          docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}:${CIRCLE_SHA1}"
-          secret_arn: "arn:aws:ssm:${AWS_DEFAULT_REGION}:${AWS_ACCOUNT_ID}:parameter/TestParameterFargateUpdate"
-          context: [CPE-OIDC]
-          role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
-      - aws-ecs/deploy_service_update:
-          name: fargate_test-update_service-job
-          auth:
-            - aws-cli/setup:
-                role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
-                profile_name: "ECS_TEST_PROFILE"
-          filters: *filters
-          requires:
-            - fargate_test-update_service-command
-          profile_name: "ECS_TEST_PROFILE"
-          family: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
-          cluster: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
-          container_env_var_updates: 'container=${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service,name=BUILD_DATE,value=$(date)'
-          # test the force_new_deployment flag
-          force_new_deployment: true
-          verify_revision_is_deployed: true
-          max_poll_attempts: 40
-          poll_interval: 10
-          context: [CPE-OIDC]
-          post-steps:
-            - test-deployment:
-                profile: "ECS_TEST_PROFILE"
-                service_name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
-                cluster: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
-      - aws-ecs/deploy_service_update:
-          name: fargate_test-update_service-skip-registration
-          auth:
-            - aws-cli/setup:
-                role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
-                profile_name: "ECS_TEST_PROFILE"
-          filters: *filters
-          requires:
-            - fargate_test-update_service-job
-          profile_name: "ECS_TEST_PROFILE"
-          family: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
-          cluster: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
-          # test skipping registration of a new task definition
-          skip_task_definition_registration: true
-          # test the enable_circuit_breaker flag
-          enable_circuit_breaker: true
-          verify_revision_is_deployed: true
-          max_poll_attempts: 40
-          poll_interval: 10
-          context: [CPE-OIDC]
-      - tear-down-test-env:
-          name: fargate_tear-down-test-env
-          filters: *filters
-          requires:
-            - fargate_test-update_service-skip-registration
-            - test-fargatespot
-          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
-          terraform-config-dir: "tests/terraform_setup/fargate"
-          context: [CPE-OIDC]
-          role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
-      #################
-      # EC2
-      #################
-      - tear-down-test-env:
-          name: ec2_tear-down-test-env-initial
-          filters: *filters
-          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
-          terraform-config-dir: "tests/terraform_setup/ec2"
-          context: [CPE-OIDC]
-          role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"      
-      - build-test-app:
-          name: ec2_build-test-app
-          docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
-          docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}:${CIRCLE_SHA1}"
-          context: [CPE-OIDC]
-          filters: *filters
-          requires:
-            - ec2_tear-down-test-env-initial
-      - set-up-test-env:
-          name: ec2_set-up-test-env
-          filters: *filters
-          requires:
-            - ec2_build-test-app
-          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
-          terraform-config-dir: "tests/terraform_setup/ec2"
-          context: [CPE-OIDC]
-          role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
-      - set-up-run_task-test:
-          name: ec2_set-up-run_task-test
-          filters: *filters
-          requires:
-            - ec2_set-up-test-env
-          family_name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360"
-          context: [CPE-OIDC]
-          role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
-      - aws-ecs/run_task:
-          name: ec2_run_task-test
-          auth:
-            - aws-cli/setup:
-                role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
-          filters: *filters
-          requires:
-            - ec2_set-up-run_task-test
-          cluster: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
-          task_definition: "${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360"
-          launch_type: "EC2"
-          awsvpc: false
-          run_task_output: "run_task_output.json"
-          overrides: '{"containerOverrides":[{"name": "${INTERPOLATION_TEST}", "memory": 512}]}'
-          context: [CPE-OIDC]
-      - tear-down-run_task-test:
-          name: ec2_tear-down-run_task-test
-          filters: *filters
-          requires:
-            - ec2_run_task-test
-          family_name: ${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360
-          context: [CPE-OIDC]
-          role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
-      - test-service-update:
-          name: ec2_test-update_service-command
-          filters: *filters
-          requires:
-            - ec2_set-up-test-env
-          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
-          family_name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
-          service_name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
-          docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
-          secret_arn: "arn:aws:ssm:${AWS_DEFAULT_REGION}:${AWS_ACCOUNT_ID}:parameter/TestParameterUpdate"
-          docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}:${CIRCLE_SHA1}"
-          context: [CPE-OIDC]
-          role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
-      - test-task_definition-update:
-          name: ec2_test-task_definition-update
-          family_name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
-          context: [CPE-OIDC]
-          role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
-          filters: *filters
-          requires:
-            - ec2_test-update_service-command
-      - aws-ecs/deploy_service_update:
-          name: ec2_test-update_service-job
-          auth:
-            - aws-cli/setup:
-                role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
-                profile_name: "ECS_TEST_PROFILE"
-          profile_name: "ECS_TEST_PROFILE"
-          context: [CPE-OIDC]
-          filters: *filters
-          requires:
-            - ec2_test-task_definition-update
-          family: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
-          service_name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
-          cluster: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
-          container_env_var_updates: 'container=${AWS_RESOURCE_NAME_PREFIX_EC2}-service,name=VERSION_INFO,value="Asterisk * expansion test ${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_EC2}-service,name=BUILD_DATE,value=$(date)'
-          verify_revision_is_deployed: true
-          fail_on_verification_timeout: false
-          post-steps:
-            - test-deployment:
-                service_name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
-                cluster: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
-                profile: "ECS_TEST_PROFILE"
-                test-asterisk-expansion: true
-      - tear-down-test-env:
-          name: ec2_tear-down-test-env
-          filters: *filters
-          requires:
-            - ec2_test-update_service-job
-            - ec2_tear-down-run_task-test
-          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
-          terraform-config-dir: "tests/terraform_setup/ec2"
-          context: [CPE-OIDC]
-          role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+      # - tear-down-test-env:
+      #     name: fargate_tear-down-test-env-initial
+      #     filters: *filters
+      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
+      #     terraform-config-dir: "tests/terraform_setup/fargate"
+      #     context: [CPE-OIDC]
+      #     role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"      
+      # - build-test-app:
+      #     name: fargate_build-test-app
+      #     docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+      #     docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}:${CIRCLE_SHA1}"
+      #     context: [CPE-OIDC]
+      #     requires:
+      #       - fargate_tear-down-test-env-initial
+      #     filters: *filters
+      # - set-up-test-env:
+      #     name: fargate_set-up-test-env
+      #     filters: *filters
+      #     requires:
+      #       - fargate_build-test-app
+      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
+      #     terraform-config-dir: "tests/terraform_setup/fargate"
+      #     context: [CPE-OIDC]
+      #     role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+      # - test-service-update:
+      #     name: fargate_test-update_service-command
+      #     filters: *filters
+      #     requires:
+      #       - fargate_set-up-test-env
+      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
+      #     family_name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
+      #     service_name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
+      #     docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+      #     docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}:${CIRCLE_SHA1}"
+      #     secret_arn: "arn:aws:ssm:${AWS_DEFAULT_REGION}:${AWS_ACCOUNT_ID}:parameter/TestParameterFargateUpdate"
+      #     context: [CPE-OIDC]
+      #     role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+      # - aws-ecs/deploy_service_update:
+      #     name: fargate_test-update_service-job
+      #     auth:
+      #       - aws-cli/setup:
+      #           role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+      #           profile_name: "ECS_TEST_PROFILE"
+      #     filters: *filters
+      #     requires:
+      #       - fargate_test-update_service-command
+      #     profile_name: "ECS_TEST_PROFILE"
+      #     family: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
+      #     cluster: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
+      #     container_env_var_updates: 'container=${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service,name=BUILD_DATE,value=$(date)'
+      #     # test the force_new_deployment flag
+      #     force_new_deployment: true
+      #     verify_revision_is_deployed: true
+      #     max_poll_attempts: 40
+      #     poll_interval: 10
+      #     context: [CPE-OIDC]
+      #     post-steps:
+      #       - test-deployment:
+      #           profile: "ECS_TEST_PROFILE"
+      #           service_name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
+      #           cluster: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
+      # - aws-ecs/deploy_service_update:
+      #     name: fargate_test-update_service-skip-registration
+      #     auth:
+      #       - aws-cli/setup:
+      #           role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+      #           profile_name: "ECS_TEST_PROFILE"
+      #     filters: *filters
+      #     requires:
+      #       - fargate_test-update_service-job
+      #     profile_name: "ECS_TEST_PROFILE"
+      #     family: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
+      #     cluster: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
+      #     # test skipping registration of a new task definition
+      #     skip_task_definition_registration: true
+      #     # test the enable_circuit_breaker flag
+      #     enable_circuit_breaker: true
+      #     verify_revision_is_deployed: true
+      #     max_poll_attempts: 40
+      #     poll_interval: 10
+      #     context: [CPE-OIDC]
+      # - tear-down-test-env:
+      #     name: fargate_tear-down-test-env
+      #     filters: *filters
+      #     requires:
+      #       - fargate_test-update_service-skip-registration
+      #       - test-fargatespot
+      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
+      #     terraform-config-dir: "tests/terraform_setup/fargate"
+      #     context: [CPE-OIDC]
+      #     role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+      # #################
+      # # EC2
+      # #################
+      # - tear-down-test-env:
+      #     name: ec2_tear-down-test-env-initial
+      #     filters: *filters
+      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
+      #     terraform-config-dir: "tests/terraform_setup/ec2"
+      #     context: [CPE-OIDC]
+      #     role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+      # - build-test-app:
+      #     name: ec2_build-test-app
+      #     docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+      #     docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}:${CIRCLE_SHA1}"
+      #     context: [CPE-OIDC]
+      #     filters: *filters
+      #     requires:
+      #       - ec2_tear-down-test-env-initial
+      # - set-up-test-env:
+      #     name: ec2_set-up-test-env
+      #     filters: *filters
+      #     requires:
+      #       - ec2_build-test-app
+      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
+      #     terraform-config-dir: "tests/terraform_setup/ec2"
+      #     context: [CPE-OIDC]
+      #     role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+      # - set-up-run_task-test:
+      #     name: ec2_set-up-run_task-test
+      #     filters: *filters
+      #     requires:
+      #       - ec2_set-up-test-env
+      #     family_name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360"
+      #     context: [CPE-OIDC]
+      #     role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+      # - aws-ecs/run_task:
+      #     name: ec2_run_task-test
+      #     auth:
+      #       - aws-cli/setup:
+      #           role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+      #     filters: *filters
+      #     requires:
+      #       - ec2_set-up-run_task-test
+      #     cluster: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
+      #     task_definition: "${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360"
+      #     launch_type: "EC2"
+      #     awsvpc: false
+      #     run_task_output: "run_task_output.json"
+      #     overrides: '{"containerOverrides":[{"name": "${INTERPOLATION_TEST}", "memory": 512}]}'
+      #     context: [CPE-OIDC]
+      # - tear-down-run_task-test:
+      #     name: ec2_tear-down-run_task-test
+      #     filters: *filters
+      #     requires:
+      #       - ec2_run_task-test
+      #     family_name: ${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360
+      #     context: [CPE-OIDC]
+      #     role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+      # - test-service-update:
+      #     name: ec2_test-update_service-command
+      #     filters: *filters
+      #     requires:
+      #       - ec2_set-up-test-env
+      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
+      #     family_name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
+      #     service_name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
+      #     docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+      #     secret_arn: "arn:aws:ssm:${AWS_DEFAULT_REGION}:${AWS_ACCOUNT_ID}:parameter/TestParameterUpdate"
+      #     docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}:${CIRCLE_SHA1}"
+      #     context: [CPE-OIDC]
+      #     role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+      # - test-task_definition-update:
+      #     name: ec2_test-task_definition-update
+      #     family_name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
+      #     context: [CPE-OIDC]
+      #     role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+      #     filters: *filters
+      #     requires:
+      #       - ec2_test-update_service-command
+      # - aws-ecs/deploy_service_update:
+      #     name: ec2_test-update_service-job
+      #     auth:
+      #       - aws-cli/setup:
+      #           role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+      #           profile_name: "ECS_TEST_PROFILE"
+      #     profile_name: "ECS_TEST_PROFILE"
+      #     context: [CPE-OIDC]
+      #     filters: *filters
+      #     requires:
+      #       - ec2_test-task_definition-update
+      #     family: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
+      #     service_name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
+      #     cluster: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
+      #     container_env_var_updates: 'container=${AWS_RESOURCE_NAME_PREFIX_EC2}-service,name=VERSION_INFO,value="Asterisk * expansion test ${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_EC2}-service,name=BUILD_DATE,value=$(date)'
+      #     verify_revision_is_deployed: true
+      #     fail_on_verification_timeout: false
+      #     post-steps:
+      #       - test-deployment:
+      #           service_name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
+      #           cluster: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
+      #           profile: "ECS_TEST_PROFILE"
+      #           test-asterisk-expansion: true
+      # - tear-down-test-env:
+      #     name: ec2_tear-down-test-env
+      #     filters: *filters
+      #     requires:
+      #       - ec2_test-update_service-job
+      #       - ec2_tear-down-run_task-test
+      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
+      #     terraform-config-dir: "tests/terraform_setup/ec2"
+      #     context: [CPE-OIDC]
+      #     role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
       # ################
       # FargateSpot
       # ################
@@ -648,11 +648,23 @@ workflows:
       #################
       # CodeDeploy
       #################
+      - tear-down-test-env:
+          name: codedeploy_fargate_tear-down-test-env-initial
+          requires:
+            - codedeploy_fargate_test-update-and-wait-service-job
+          terraform-image: "hashicorp/terraform:1.4.0"
+          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
+          terraform-config-dir: "tests/terraform_setup/fargate_codedeploy"
+          context: [CPE-OIDC]
+          role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+          filters: *filters
       - build-test-app:
           name: codedeploy_fargate_build-test-app
           docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com"
           docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
           context: [CPE-OIDC]
+          requires:
+          - codedeploy_fargate_tear-down-test-env-initial
           filters: *filters
       - set-up-test-env:
           name: codedeploy_fargate_set-up-test-env
@@ -755,7 +767,8 @@ workflows:
           pub_type: production
           enable_pr_comment: true
           context: orb-publisher
-          requires: [orb-tools/pack, ec2_tear-down-test-env, fargate_tear-down-test-env, integration-test-ecs-cli-install]
+          # requires: [orb-tools/pack, ec2_tear-down-test-env, fargate_tear-down-test-env, codedeploy_fargate_tear-down-test-env, integration-test-ecs-cli-install]
+          requires: [orb-tools/pack, codedeploy_fargate_tear-down-test-env, integration-test-ecs-cli-install]
           filters: *release-filters
 commands:
   wait-for-codedeploy-deployment:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -645,6 +645,108 @@ workflows:
           role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
           requires:
             - fargate_set-up-test-env
+      #################
+      # CodeDeploy
+      #################
+      - build-test-app:
+          name: codedeploy_fargate_build-test-app
+          docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com"
+          docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
+          context: [CPE-OIDC]
+          filters: *filters
+      - set-up-test-env:
+          name: codedeploy_fargate_set-up-test-env
+          filters: *filters
+          requires:
+            - codedeploy_fargate_build-test-app
+          terraform-image: "hashicorp/terraform:1.4.0"
+          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
+          terraform-config-dir: "tests/terraform_setup/fargate_codedeploy"
+          context: [CPE-OIDC]
+          role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+      - test-service-update:
+          name: codedeploy_fargate_test-update_service-command
+          filters: *filters
+          requires:
+            - codedeploy_fargate_set-up-test-env
+          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
+          family_name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+          service_name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+          docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com"
+          docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
+          role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+          skip-service-update: true
+          context: [CPE-OIDC]
+      - aws-ecs/deploy_service_update:
+          name: codedeploy_fargate_test-update_service-job
+          auth:
+            - aws-cli/setup:
+                role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+          filters: *filters
+          requires:
+            - codedeploy_fargate_test-update_service-command
+          region: AWS_REGION
+          family: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+          cluster: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+          container_image_name_updates: "container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,image-and-tag=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
+          container_env_var_updates: 'container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=BUILD_DATE,value=$(date)'
+          deployment_controller: "CODE_DEPLOY"
+          codedeploy_application_name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeployapp"
+          codedeploy_deployment_group_name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
+          codedeploy_load_balanced_container_name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+          codedeploy_load_balanced_container_port: 80
+          codedeploy_capacity_provider_name: "FARGATE"
+          codedeploy_capacity_provider_base: "1"
+          codedeploy_capacity_provider_weight: "2"
+          verify_revision_is_deployed: false
+          context: [CPE-OIDC]
+          post-steps:
+            - wait-for-codedeploy-deployment:
+                application-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeployapp"
+                deployment-group-name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
+            - test-deployment:
+                service_name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+                cluster: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+                delete-load-balancer: false
+      - aws-ecs/deploy_service_update:
+          name: codedeploy_fargate_test-update-and-wait-service-job
+          auth:
+            - aws-cli/setup:
+                role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+          context: [CPE-OIDC]
+          filters: *filters
+          requires:
+            - codedeploy_fargate_test-update_service-job
+          region: AWS_REGION
+          family: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+          cluster: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+          container_image_name_updates: "container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,image-and-tag=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
+          container_env_var_updates: 'container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,name=BUILD_DATE,value=$(date)'
+          deployment_controller: "CODE_DEPLOY"
+          codedeploy_application_name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeployapp"
+          codedeploy_deployment_group_name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
+          codedeploy_load_balanced_container_name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+          codedeploy_load_balanced_container_port: 80
+          verify_revision_is_deployed: true
+          verification_timeout: "12m"
+          post-steps:
+            - test-deployment:
+                service_name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+                cluster: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+                delete-load-balancer: true
+            - delete-service:
+                service_name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
+                cluster: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
+      - tear-down-test-env:
+          name: codedeploy_fargate_tear-down-test-env
+          requires:
+            - codedeploy_fargate_test-update-and-wait-service-job
+          terraform-image: "hashicorp/terraform:1.4.0"
+          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
+          terraform-config-dir: "tests/terraform_setup/fargate_codedeploy"
+          context: [CPE-OIDC]
+          role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+          filters: *filters
       - orb-tools/pack:
           filters: *release-filters
       - orb-tools/publish:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -758,6 +758,44 @@ workflows:
           requires: [orb-tools/pack, ec2_tear-down-test-env, fargate_tear-down-test-env, integration-test-ecs-cli-install]
           filters: *release-filters
 commands:
+  wait-for-codedeploy-deployment:
+    description: "Wait for the CodeDeploy deployment to be successful"
+    parameters:
+      application-name:
+        description: "CodeDeploy application name"
+        type: string
+      deployment-group-name:
+        description: "CodeDeploy application name"
+        type: string
+    steps:
+      - run:
+          name: Wait for CodeDeploy deployment to be successful (for orb testing and is not part of the orb)
+          command: |
+            DEPLOYMENT_ID=$(aws deploy list-deployments \
+              --application-name << parameters.application-name >> \
+              --deployment-group-name << parameters.deployment-group-name >> \
+              --query "deployments" \
+              --max-items 1 \
+              --output text \
+              | head -n 1)
+            aws deploy wait deployment-successful --deployment-id ${DEPLOYMENT_ID}
+  delete-service:
+    description: "Forcefully delete an ECS service"
+    parameters:
+      service_name:
+        description: "Name of the ECS service"
+        type: string
+      cluster:
+        description: "Name of the cluster"
+        type: string
+    steps:
+      - run:
+          name: Delete ECS service
+          command: |
+            aws ecs delete-service \
+              --cluster << parameters.cluster>> \
+              --service << parameters.service_name >> \
+              --force
   test-deployment:
     description: "Test the deployment"
     parameters:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -744,6 +744,7 @@ workflows:
                 service_name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
                 cluster: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
                 delete-load-balancer: true
+                port: "8080"
             - delete-service:
                 service_name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
                 cluster: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -694,7 +694,7 @@ workflows:
           codedeploy_application_name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeployapp"
           codedeploy_deployment_group_name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
           codedeploy_load_balanced_container_name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-          codedeploy_load_balanced_container_port: 80
+          codedeploy_load_balanced_container_port: "80"
           codedeploy_capacity_provider_name: "FARGATE"
           codedeploy_capacity_provider_base: "1"
           codedeploy_capacity_provider_weight: "2"
@@ -726,7 +726,7 @@ workflows:
           codedeploy_application_name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeployapp"
           codedeploy_deployment_group_name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-codedeploygroup"
           codedeploy_load_balanced_container_name: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
-          codedeploy_load_balanced_container_port: 80
+          codedeploy_load_balanced_container_port: "80"
           verify_revision_is_deployed: true
           verification_timeout: "12m"
           post-steps:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -650,8 +650,6 @@ workflows:
       #################
       - tear-down-test-env:
           name: codedeploy_fargate_tear-down-test-env-initial
-          requires:
-            - codedeploy_fargate_test-update-and-wait-service-job
           terraform-image: "hashicorp/terraform:1.4.0"
           aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}
           terraform-config-dir: "tests/terraform_setup/fargate_codedeploy"

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -433,218 +433,218 @@ workflows:
       #################
       # Fargate
       #################
-      # - tear-down-test-env:
-      #     name: fargate_tear-down-test-env-initial
-      #     filters: *filters
-      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
-      #     terraform-config-dir: "tests/terraform_setup/fargate"
-      #     context: [CPE-OIDC]
-      #     role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"      
-      # - build-test-app:
-      #     name: fargate_build-test-app
-      #     docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
-      #     docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}:${CIRCLE_SHA1}"
-      #     context: [CPE-OIDC]
-      #     requires:
-      #       - fargate_tear-down-test-env-initial
-      #     filters: *filters
-      # - set-up-test-env:
-      #     name: fargate_set-up-test-env
-      #     filters: *filters
-      #     requires:
-      #       - fargate_build-test-app
-      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
-      #     terraform-config-dir: "tests/terraform_setup/fargate"
-      #     context: [CPE-OIDC]
-      #     role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
-      # - test-service-update:
-      #     name: fargate_test-update_service-command
-      #     filters: *filters
-      #     requires:
-      #       - fargate_set-up-test-env
-      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
-      #     family_name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
-      #     service_name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
-      #     docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
-      #     docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}:${CIRCLE_SHA1}"
-      #     secret_arn: "arn:aws:ssm:${AWS_DEFAULT_REGION}:${AWS_ACCOUNT_ID}:parameter/TestParameterFargateUpdate"
-      #     context: [CPE-OIDC]
-      #     role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
-      # - aws-ecs/deploy_service_update:
-      #     name: fargate_test-update_service-job
-      #     auth:
-      #       - aws-cli/setup:
-      #           role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
-      #           profile_name: "ECS_TEST_PROFILE"
-      #     filters: *filters
-      #     requires:
-      #       - fargate_test-update_service-command
-      #     profile_name: "ECS_TEST_PROFILE"
-      #     family: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
-      #     cluster: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
-      #     container_env_var_updates: 'container=${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service,name=BUILD_DATE,value=$(date)'
-      #     # test the force_new_deployment flag
-      #     force_new_deployment: true
-      #     verify_revision_is_deployed: true
-      #     max_poll_attempts: 40
-      #     poll_interval: 10
-      #     context: [CPE-OIDC]
-      #     post-steps:
-      #       - test-deployment:
-      #           profile: "ECS_TEST_PROFILE"
-      #           service_name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
-      #           cluster: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
-      # - aws-ecs/deploy_service_update:
-      #     name: fargate_test-update_service-skip-registration
-      #     auth:
-      #       - aws-cli/setup:
-      #           role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
-      #           profile_name: "ECS_TEST_PROFILE"
-      #     filters: *filters
-      #     requires:
-      #       - fargate_test-update_service-job
-      #     profile_name: "ECS_TEST_PROFILE"
-      #     family: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
-      #     cluster: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
-      #     # test skipping registration of a new task definition
-      #     skip_task_definition_registration: true
-      #     # test the enable_circuit_breaker flag
-      #     enable_circuit_breaker: true
-      #     verify_revision_is_deployed: true
-      #     max_poll_attempts: 40
-      #     poll_interval: 10
-      #     context: [CPE-OIDC]
-      # - tear-down-test-env:
-      #     name: fargate_tear-down-test-env
-      #     filters: *filters
-      #     requires:
-      #       - fargate_test-update_service-skip-registration
-      #       - test-fargatespot
-      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
-      #     terraform-config-dir: "tests/terraform_setup/fargate"
-      #     context: [CPE-OIDC]
-      #     role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+      - tear-down-test-env:
+          name: fargate_tear-down-test-env-initial
+          filters: *filters
+          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
+          terraform-config-dir: "tests/terraform_setup/fargate"
+          context: [CPE-OIDC]
+          role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"      
+      - build-test-app:
+          name: fargate_build-test-app
+          docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+          docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}:${CIRCLE_SHA1}"
+          context: [CPE-OIDC]
+          requires:
+            - fargate_tear-down-test-env-initial
+          filters: *filters
+      - set-up-test-env:
+          name: fargate_set-up-test-env
+          filters: *filters
+          requires:
+            - fargate_build-test-app
+          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
+          terraform-config-dir: "tests/terraform_setup/fargate"
+          context: [CPE-OIDC]
+          role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+      - test-service-update:
+          name: fargate_test-update_service-command
+          filters: *filters
+          requires:
+            - fargate_set-up-test-env
+          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
+          family_name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
+          service_name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
+          docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+          docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}:${CIRCLE_SHA1}"
+          secret_arn: "arn:aws:ssm:${AWS_DEFAULT_REGION}:${AWS_ACCOUNT_ID}:parameter/TestParameterFargateUpdate"
+          context: [CPE-OIDC]
+          role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+      - aws-ecs/deploy_service_update:
+          name: fargate_test-update_service-job
+          auth:
+            - aws-cli/setup:
+                role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+                profile_name: "ECS_TEST_PROFILE"
+          filters: *filters
+          requires:
+            - fargate_test-update_service-command
+          profile_name: "ECS_TEST_PROFILE"
+          family: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
+          cluster: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
+          container_env_var_updates: 'container=${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service,name=VERSION_INFO,value="${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service,name=BUILD_DATE,value=$(date)'
+          # test the force_new_deployment flag
+          force_new_deployment: true
+          verify_revision_is_deployed: true
+          max_poll_attempts: 40
+          poll_interval: 10
+          context: [CPE-OIDC]
+          post-steps:
+            - test-deployment:
+                profile: "ECS_TEST_PROFILE"
+                service_name: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
+                cluster: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
+      - aws-ecs/deploy_service_update:
+          name: fargate_test-update_service-skip-registration
+          auth:
+            - aws-cli/setup:
+                role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+                profile_name: "ECS_TEST_PROFILE"
+          filters: *filters
+          requires:
+            - fargate_test-update_service-job
+          profile_name: "ECS_TEST_PROFILE"
+          family: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-service"
+          cluster: "${AWS_RESOURCE_NAME_PREFIX_FARGATE}-cluster"
+          # test skipping registration of a new task definition
+          skip_task_definition_registration: true
+          # test the enable_circuit_breaker flag
+          enable_circuit_breaker: true
+          verify_revision_is_deployed: true
+          max_poll_attempts: 40
+          poll_interval: 10
+          context: [CPE-OIDC]
+      - tear-down-test-env:
+          name: fargate_tear-down-test-env
+          filters: *filters
+          requires:
+            - fargate_test-update_service-skip-registration
+            - test-fargatespot
+          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_FARGATE}
+          terraform-config-dir: "tests/terraform_setup/fargate"
+          context: [CPE-OIDC]
+          role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
       # #################
       # # EC2
       # #################
-      # - tear-down-test-env:
-      #     name: ec2_tear-down-test-env-initial
-      #     filters: *filters
-      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
-      #     terraform-config-dir: "tests/terraform_setup/ec2"
-      #     context: [CPE-OIDC]
-      #     role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
-      # - build-test-app:
-      #     name: ec2_build-test-app
-      #     docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
-      #     docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}:${CIRCLE_SHA1}"
-      #     context: [CPE-OIDC]
-      #     filters: *filters
-      #     requires:
-      #       - ec2_tear-down-test-env-initial
-      # - set-up-test-env:
-      #     name: ec2_set-up-test-env
-      #     filters: *filters
-      #     requires:
-      #       - ec2_build-test-app
-      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
-      #     terraform-config-dir: "tests/terraform_setup/ec2"
-      #     context: [CPE-OIDC]
-      #     role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
-      # - set-up-run_task-test:
-      #     name: ec2_set-up-run_task-test
-      #     filters: *filters
-      #     requires:
-      #       - ec2_set-up-test-env
-      #     family_name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360"
-      #     context: [CPE-OIDC]
-      #     role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
-      # - aws-ecs/run_task:
-      #     name: ec2_run_task-test
-      #     auth:
-      #       - aws-cli/setup:
-      #           role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
-      #     filters: *filters
-      #     requires:
-      #       - ec2_set-up-run_task-test
-      #     cluster: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
-      #     task_definition: "${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360"
-      #     launch_type: "EC2"
-      #     awsvpc: false
-      #     run_task_output: "run_task_output.json"
-      #     overrides: '{"containerOverrides":[{"name": "${INTERPOLATION_TEST}", "memory": 512}]}'
-      #     context: [CPE-OIDC]
-      # - tear-down-run_task-test:
-      #     name: ec2_tear-down-run_task-test
-      #     filters: *filters
-      #     requires:
-      #       - ec2_run_task-test
-      #     family_name: ${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360
-      #     context: [CPE-OIDC]
-      #     role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
-      # - test-service-update:
-      #     name: ec2_test-update_service-command
-      #     filters: *filters
-      #     requires:
-      #       - ec2_set-up-test-env
-      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
-      #     family_name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
-      #     service_name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
-      #     docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
-      #     secret_arn: "arn:aws:ssm:${AWS_DEFAULT_REGION}:${AWS_ACCOUNT_ID}:parameter/TestParameterUpdate"
-      #     docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}:${CIRCLE_SHA1}"
-      #     context: [CPE-OIDC]
-      #     role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
-      # - test-task_definition-update:
-      #     name: ec2_test-task_definition-update
-      #     family_name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
-      #     context: [CPE-OIDC]
-      #     role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
-      #     filters: *filters
-      #     requires:
-      #       - ec2_test-update_service-command
-      # - aws-ecs/deploy_service_update:
-      #     name: ec2_test-update_service-job
-      #     auth:
-      #       - aws-cli/setup:
-      #           role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
-      #           profile_name: "ECS_TEST_PROFILE"
-      #     profile_name: "ECS_TEST_PROFILE"
-      #     context: [CPE-OIDC]
-      #     filters: *filters
-      #     requires:
-      #       - ec2_test-task_definition-update
-      #     family: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
-      #     service_name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
-      #     cluster: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
-      #     container_env_var_updates: 'container=${AWS_RESOURCE_NAME_PREFIX_EC2}-service,name=VERSION_INFO,value="Asterisk * expansion test ${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_EC2}-service,name=BUILD_DATE,value=$(date)'
-      #     verify_revision_is_deployed: true
-      #     fail_on_verification_timeout: false
-      #     post-steps:
-      #       - test-deployment:
-      #           service_name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
-      #           cluster: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
-      #           profile: "ECS_TEST_PROFILE"
-      #           test-asterisk-expansion: true
-      # - tear-down-test-env:
-      #     name: ec2_tear-down-test-env
-      #     filters: *filters
-      #     requires:
-      #       - ec2_test-update_service-job
-      #       - ec2_tear-down-run_task-test
-      #     aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
-      #     terraform-config-dir: "tests/terraform_setup/ec2"
-      #     context: [CPE-OIDC]
-      #     role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+      - tear-down-test-env:
+          name: ec2_tear-down-test-env-initial
+          filters: *filters
+          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
+          terraform-config-dir: "tests/terraform_setup/ec2"
+          context: [CPE-OIDC]
+          role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+      - build-test-app:
+          name: ec2_build-test-app
+          docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+          docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}:${CIRCLE_SHA1}"
+          context: [CPE-OIDC]
+          filters: *filters
+          requires:
+            - ec2_tear-down-test-env-initial
+      - set-up-test-env:
+          name: ec2_set-up-test-env
+          filters: *filters
+          requires:
+            - ec2_build-test-app
+          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
+          terraform-config-dir: "tests/terraform_setup/ec2"
+          context: [CPE-OIDC]
+          role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+      - set-up-run_task-test:
+          name: ec2_set-up-run_task-test
+          filters: *filters
+          requires:
+            - ec2_set-up-test-env
+          family_name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360"
+          context: [CPE-OIDC]
+          role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+      - aws-ecs/run_task:
+          name: ec2_run_task-test
+          auth:
+            - aws-cli/setup:
+                role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+          filters: *filters
+          requires:
+            - ec2_set-up-run_task-test
+          cluster: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
+          task_definition: "${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360"
+          launch_type: "EC2"
+          awsvpc: false
+          run_task_output: "run_task_output.json"
+          overrides: '{"containerOverrides":[{"name": "${INTERPOLATION_TEST}", "memory": 512}]}'
+          context: [CPE-OIDC]
+      - tear-down-run_task-test:
+          name: ec2_tear-down-run_task-test
+          filters: *filters
+          requires:
+            - ec2_run_task-test
+          family_name: ${AWS_RESOURCE_NAME_PREFIX_EC2}-sleep360
+          context: [CPE-OIDC]
+          role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+      - test-service-update:
+          name: ec2_test-update_service-command
+          filters: *filters
+          requires:
+            - ec2_set-up-test-env
+          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
+          family_name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
+          service_name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
+          docker-image-namespace: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com"
+          secret_arn: "arn:aws:ssm:${AWS_DEFAULT_REGION}:${AWS_ACCOUNT_ID}:parameter/TestParameterUpdate"
+          docker-image-name: "${AWS_RESOURCE_NAME_PREFIX_EC2}:${CIRCLE_SHA1}"
+          context: [CPE-OIDC]
+          role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+      - test-task_definition-update:
+          name: ec2_test-task_definition-update
+          family_name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
+          context: [CPE-OIDC]
+          role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+          filters: *filters
+          requires:
+            - ec2_test-update_service-command
+      - aws-ecs/deploy_service_update:
+          name: ec2_test-update_service-job
+          auth:
+            - aws-cli/setup:
+                role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+                profile_name: "ECS_TEST_PROFILE"
+          profile_name: "ECS_TEST_PROFILE"
+          context: [CPE-OIDC]
+          filters: *filters
+          requires:
+            - ec2_test-task_definition-update
+          family: "${AWS_RESOURCE_NAME_PREFIX_EC2}-family"
+          service_name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
+          cluster: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
+          container_env_var_updates: 'container=${AWS_RESOURCE_NAME_PREFIX_EC2}-service,name=VERSION_INFO,value="Asterisk * expansion test ${CIRCLE_SHA1}_${CIRCLE_BUILD_NUM}",container=${AWS_RESOURCE_NAME_PREFIX_EC2}-service,name=BUILD_DATE,value=$(date)'
+          verify_revision_is_deployed: true
+          fail_on_verification_timeout: false
+          post-steps:
+            - test-deployment:
+                service_name: "${AWS_RESOURCE_NAME_PREFIX_EC2}-service"
+                cluster: "${AWS_RESOURCE_NAME_PREFIX_EC2}-cluster"
+                profile: "ECS_TEST_PROFILE"
+                test-asterisk-expansion: true
+      - tear-down-test-env:
+          name: ec2_tear-down-test-env
+          filters: *filters
+          requires:
+            - ec2_test-update_service-job
+            - ec2_tear-down-run_task-test
+          aws-resource-name-prefix: ${AWS_RESOURCE_NAME_PREFIX_EC2}
+          terraform-config-dir: "tests/terraform_setup/ec2"
+          context: [CPE-OIDC]
+          role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
       # ################
       # FargateSpot
       # ################
-      # - test-fargatespot:
-      #     context: [CPE-OIDC]
-      #     filters: *filters
-      #     role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
-      #     requires:
-      #       - fargate_set-up-test-env
+      - test-fargatespot:
+          context: [CPE-OIDC]
+          filters: *filters
+          role_arn: "arn:aws:iam::122211685980:role/CPE_ECS_OIDC_TEST"
+          requires:
+            - fargate_set-up-test-env
       #################
       # CodeDeploy
       #################
@@ -766,8 +766,7 @@ workflows:
           pub_type: production
           enable_pr_comment: true
           context: orb-publisher
-          # requires: [orb-tools/pack, ec2_tear-down-test-env, fargate_tear-down-test-env, codedeploy_fargate_tear-down-test-env, integration-test-ecs-cli-install]
-          requires: [orb-tools/pack, codedeploy_fargate_tear-down-test-env, integration-test-ecs-cli-install]
+          requires: [orb-tools/pack, ec2_tear-down-test-env, fargate_tear-down-test-env, codedeploy_fargate_tear-down-test-env, integration-test-ecs-cli-install]
           filters: *release-filters
 commands:
   wait-for-codedeploy-deployment:

--- a/tests/terraform_setup/fargate_codedeploy/alb.tf
+++ b/tests/terraform_setup/fargate_codedeploy/alb.tf
@@ -53,7 +53,7 @@ resource "aws_alb_listener" "front_end_green" {
     type             = "forward"
   }
   lifecycle {
-    ignore_changes = [action] 
+    ignore_changes = [default_action] 
   }
 }
 
@@ -67,6 +67,6 @@ resource "aws_alb_listener" "front_end_blue" {
     type             = "forward"
   }
   lifecycle {
-    ignore_changes = [action] 
+    ignore_changes = [default_action] 
   }
 }

--- a/tests/terraform_setup/fargate_codedeploy/alb.tf
+++ b/tests/terraform_setup/fargate_codedeploy/alb.tf
@@ -52,6 +52,9 @@ resource "aws_alb_listener" "front_end_green" {
     target_group_arn = aws_alb_target_group.green.id
     type             = "forward"
   }
+  lifecycle {
+    ignore_changes = [action] 
+  }
 }
 
 resource "aws_alb_listener" "front_end_blue" {
@@ -62,5 +65,8 @@ resource "aws_alb_listener" "front_end_blue" {
   default_action {
     target_group_arn = aws_alb_target_group.blue.id
     type             = "forward"
+  }
+  lifecycle {
+    ignore_changes = [action] 
   }
 }

--- a/tests/terraform_setup/fargate_codedeploy/ecs.tf
+++ b/tests/terraform_setup/fargate_codedeploy/ecs.tf
@@ -56,7 +56,9 @@ resource "aws_ecs_service" "ecs_service" {
   }
 
   depends_on = [aws_alb_listener.front_end_blue, aws_iam_role_policy_attachment.ecs_task_execution_role]
-
+  lifecycle {
+    ignore_changes = [load_balancer, task_definition]
+  }
 }
 
 # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/codedeploy_IAM_role.html

--- a/tests/terraform_setup/fargate_codedeploy/terraform.tf
+++ b/tests/terraform_setup/fargate_codedeploy/terraform.tf
@@ -14,9 +14,6 @@ terraform {
 }
 
 provider "aws" {
-  access_key = var.aws_access_key
-  secret_key = var.aws_secret_key
-  token = var.aws_session_token
   region     = var.aws_region
 }
 
@@ -28,14 +25,4 @@ locals {
 resource "aws_ecr_repository" "demo-app-repository" {
   name = local.aws_ecr_repository_name
   force_delete = true
-}
-
-resource "aws_ssm_parameter" "test_container_secret" {
-  name  = var.aws_resource_prefix
-  type  = "String"
-  value = "test_value"
-}
-
-output "arn_secret" {
-  value = aws_ssm_parameter.test_container_secret.arn
 }

--- a/tests/terraform_setup/fargate_codedeploy/variables.tf
+++ b/tests/terraform_setup/fargate_codedeploy/variables.tf
@@ -1,7 +1,3 @@
-variable "aws_access_key" {}
-variable "aws_secret_key" {}
-variable "aws_account_id" {}
-variable "aws_session_token" {}
 variable "aws_region" {
   description = "AWS region e.g. us-east-1 (Please specify a region supported by the Fargate launch type)"
 }

--- a/tests/terraform_setup/fargate_codedeploy/variables.tf
+++ b/tests/terraform_setup/fargate_codedeploy/variables.tf
@@ -4,7 +4,7 @@ variable "aws_region" {
 variable "aws_resource_prefix" {
   description = "Prefix to be used in the naming of the created AWS resources e.g. ecs-fargate"
 }
-
+variable "aws_account_id" {}
 variable "az_count" {
   default = "2"
 }


### PR DESCRIPTION
Previously I had removed Code Deploy tests as they were failing, and it looked like it was impossible to run. I'm fixing the tests and re adding them again to make sure we are not breaking this functionality.