### PR TITLE
feat(update_service): allow to override aws region by parameter

### DIFF
--- a/src/commands/update_service.yml
+++ b/src/commands/update_service.yml
@@ -1,6 +1,10 @@
 description: >
   Registers a task definition for the given ECS service and updates the service to use it. Optionally polls the status of the deployment until the created task definition revision has reached its desired running task count and is the only revision deployed for the service.
 parameters:
+  region:
+    description: AWS region to use for looking up task definitions.
+    type: string
+    default: $AWS_DEFAULT_REGION
   family:
     description: Name of the task definition's family.
     type: string
@@ -207,7 +211,7 @@ steps:
                 --output text \
                 --query 'taskDefinition.taskDefinitionArn' \
                 --profile << parameters.profile_name >> \
-                --region ${AWS_DEFAULT_REGION})
+                --region << parameters.region >>
               echo "export CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN='${TASK_DEFINITION_ARN}'" >> $BASH_ENV
   - when:
       condition: << parameters.task_definition_tags >>

--- a/src/commands/update_service.yml
+++ b/src/commands/update_service.yml
@@ -211,7 +211,7 @@ steps:
                 --output text \
                 --query 'taskDefinition.taskDefinitionArn' \
                 --profile << parameters.profile_name >> \
-                --region << parameters.region >>
+                --region << parameters.region >>)
               echo "export CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN='${TASK_DEFINITION_ARN}'" >> $BASH_ENV
   - when:
       condition: << parameters.task_definition_tags >>


### PR DESCRIPTION
In #207 an feature was introduced to define a region for the task definition lookup. I don't know why this was a fix, because the AWS CLI should always use AWS_DEFAULT_REGION if defined as environment variable without the need to explicitly provide it as a parameter.

Thus i came across an issue where i need to define the environment variable AWS_DEFAULT_REGION for a job which points to another region for my ecr which is not in the same region as my task definition. Basically the job cannot be used for cross-region deployment this way.

As a fix, i added a new parameter "region" which can be overridden for those cases, but will default to AWS_DEFAULT_REGION environment variable to not break current usage of the update_service command.

This might be treated as minor change in sense of semantic versioning.