### PR TITLE
fix: change `ORB_STR_RULE_NAME` validation to fail when the it's empty

### DIFF
--- a/src/scripts/deploy_ecs_scheduled_task.sh
+++ b/src/scripts/deploy_ecs_scheduled_task.sh
@@ -8,7 +8,7 @@ fi
 
 ORB_STR_RULE_NAME="$(circleci env subst "${ORB_STR_RULE_NAME}")"
 
-if [[ -n $ORB_STR_RULE_NAME ]]; then
+if [ -z "$ORB_STR_RULE_NAME" ]; then
     echo "To deploy with an scheduled task, you must provide a rule name"
     exit 1
 fi


### PR DESCRIPTION
refs to https://github.com/CircleCI-Public/aws-ecs-orb/issues/222

I changed the rule to verify if the `ORB_STR_RULE_NAME` is not empty (default value). Previously it was checking if it's not set but it's being set at line 9 with an empty value:
```
ORB_STR_RULE_NAME="$(circleci env subst "${ORB_STR_RULE_NAME}")"
```
and the rule name is required to invoke the next AWS CLI commands, if it's empty it'll fail