### PR TITLE
Feature: job parameter region for all the commands and jobs

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -880,6 +880,8 @@ executors:
   mac:
     macos:
       xcode: 13.4.1
+      shell: bash -eox pipefail
   linux:
     docker:
       - image: cimg/base:current
+        shell: bash -eox pipefail

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -695,7 +695,7 @@ workflows:
           filters: *filters
           requires:
             - codedeploy_fargate_test-update_service-command
-          region: AWS_REGION
+          region: $AWS_REGION
           family: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
           cluster: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
           container_image_name_updates: "container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,image-and-tag=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"
@@ -727,7 +727,7 @@ workflows:
           filters: *filters
           requires:
             - codedeploy_fargate_test-update_service-job
-          region: AWS_REGION
+          region: $AWS_REGION
           family: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service"
           cluster: "${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-cluster"
           container_image_name_updates: "container=${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}-service,image-and-tag=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${AWS_RESOURCE_NAME_PREFIX_CODEDEPLOY_FARGATE}:${CIRCLE_SHA1}"

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -884,4 +884,4 @@ executors:
   linux:
     docker:
       - image: cimg/base:current
-        shell: bash -eox pipefail
+      shell: bash -eox pipefail

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -880,8 +880,8 @@ executors:
   mac:
     macos:
       xcode: 13.4.1
-      shell: bash -eox pipefail
+    shell: bash -eox pipefail
   linux:
     docker:
       - image: cimg/base:current
-      shell: bash -eox pipefail
+    shell: bash -eox pipefail

--- a/src/commands/deploy_ecs_scheduled_task.yml
+++ b/src/commands/deploy_ecs_scheduled_task.yml
@@ -5,9 +5,14 @@ parameters:
   rule_name:
     description: The name of the scheduled task's rule to update.
     type: string
+  region:
+    description: AWS region to use. Defaults to AWS_DEFAULT_REGION environment variable.
+    type: string
+    default: $AWS_DEFAULT_REGION
 steps:
   - run:
       name: Deploy rule with updated task definition
       environment:
         ORB_STR_RULE_NAME: <<parameters.rule_name>>
+        ORB_AWS_REGION: << parameters.region >>
       command: <<include(scripts/deploy_ecs_scheduled_task.sh)>>

--- a/src/commands/run_task.yml
+++ b/src/commands/run_task.yml
@@ -124,6 +124,10 @@ parameters:
           Specifies a local json file to save the output logs from the aws ecs run_task command. Use tools like JQ to read and parse this information such as "task-arns" and "task-ids"
     type: string
     default: ''
+  region:
+    description: AWS region to use. Defaults to AWS_DEFAULT_REGION environment variable.
+    type: string
+    default: $AWS_DEFAULT_REGION
 steps:
   - run:
       name: Run Task
@@ -140,6 +144,7 @@ steps:
         ORB_STR_PLATFORM_VERSION: <<parameters.platform_version>>
         ORB_BOOL_AWSVPC: <<parameters.awsvpc>>
         ORB_STR_SUBNET_ID: <<parameters.subnet_ids>>
+        ORB_AWS_REGION: << parameters.region >>
         ORB_STR_SEC_GROUP_ID: <<parameters.security_group_ids>>
         ORB_STR_ASSIGN_PUB_IP: <<parameters.assign_public_ip>>
         ORB_STR_OVERRIDES: <<parameters.overrides>>

--- a/src/commands/update_service.yml
+++ b/src/commands/update_service.yml
@@ -200,6 +200,7 @@ steps:
             container_secret_updates: << parameters.container_secret_updates >>
             container_docker_label_updates: << parameters.container_docker_label_updates >>
             profile_name: << parameters.profile_name >>
+            region: << parameters.region >>
   - when:
       condition: << parameters.skip_task_definition_registration >>
       steps:
@@ -222,7 +223,8 @@ steps:
               aws ecs tag-resource \
                 --resource-arn ${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN} \
                 --tags <<parameters.task_definition_tags>> \
-                --profile=<< parameters.profile_name >>
+                --profile=<< parameters.profile_name >> \
+                --region << parameters.region >>
   - when:
       condition:
         equal:
@@ -241,6 +243,7 @@ steps:
               ORB_INT_CD_LOAD_BALANCED_CONTAINER_PORT: <<parameters.codedeploy_load_balanced_container_port>>
               ORB_BOOL_VERIFY_REV_DEPLOY: <<parameters.verify_revision_is_deployed>>
               ORB_STR_PROFILE_NAME: <<parameters.profile_name>>
+              ORB_AWS_REGION: << parameters.region >>
               ORB_BOOL_ENABLE_CIRCUIT_BREAKER: <<parameters.enable_circuit_breaker>>
               ORB_STR_CD_CAPACITY_PROVIDER_NAME: <<parameters.codedeploy_capacity_provider_name>>
               ORB_STR_CD_CAPACITY_PROVIDER_WEIGHT: <<parameters.codedeploy_capacity_provider_weight>>
@@ -261,6 +264,7 @@ steps:
               ORB_STR_FAMILY: <<parameters.family>>
               ORB_BOOL_FORCE_NEW_DEPLOY: <<parameters.force_new_deployment>>
               ORB_STR_CLUSTER_NAME: <<parameters.cluster>>
+              ORB_AWS_REGION: << parameters.region >>
               ORB_STR_PROFILE_NAME: <<parameters.profile_name>>
               ORB_BOOL_ENABLE_CIRCUIT_BREAKER: <<parameters.enable_circuit_breaker>>
 
@@ -279,5 +283,6 @@ steps:
             task_definition_arn: $CCI_ORB_AWS_ECS_DEPLOYED_REVISION
             max_poll_attempts: << parameters.max_poll_attempts >>
             poll_interval: << parameters.poll_interval >>
+            region: << parameters.region >>
             fail_on_verification_timeout: << parameters.fail_on_verification_timeout >>
             profile_name: << parameters.profile_name >>

--- a/src/commands/update_task_definition.yml
+++ b/src/commands/update_task_definition.yml
@@ -64,6 +64,10 @@ parameters:
     description: Optional previous task's revision number
     type: string
     default: ''
+  region:
+    description: AWS region to use. Defaults to AWS_DEFAULT_REGION environment variable.
+    type: string
+    default: $AWS_DEFAULT_REGION
 steps:
   - run:
       name: Retrieve previous task definition and prepare new task definition values
@@ -76,6 +80,7 @@ steps:
         ORB_SCRIPT_GET_TASK_DFN_VAL: <<include(scripts/get_task_dfn_val.py)>>
         ORB_STR_PROFILE_NAME: <<parameters.profile_name>>
         ORB_STR_PREVIOUS_REVISION_NUMBER: <<parameters.previous_revision_number>>
+        ORB_AWS_REGION: << parameters.region >>
         ORB_STR_CONTAINER_SECRET_UPDATES: <<parameters.container_secret_updates>>
         ORB_STR_CONTAINER_DOCKER_LABEL_UPDATES: << parameters.container_docker_label_updates >>
   - run:

--- a/src/commands/update_task_definition.yml
+++ b/src/commands/update_task_definition.yml
@@ -89,3 +89,4 @@ steps:
       environment:
         ORB_STR_FAMILY: <<parameters.family>>
         ORB_STR_PROFILE_NAME: <<parameters.profile_name>>
+        ORB_AWS_REGION: << parameters.region >>

--- a/src/commands/update_task_definition_from_json.yml
+++ b/src/commands/update_task_definition_from_json.yml
@@ -8,6 +8,10 @@ parameters:
     description: AWS profile name to be configured.
     type: string
     default: "default"
+  region:
+    description: AWS region to use. Defaults to AWS_DEFAULT_REGION environment variable.
+    type: string
+    default: $AWS_DEFAULT_REGION
 steps:
   - run:
       name: Register new task definition
@@ -15,3 +19,4 @@ steps:
       environment:
         ORB_STR_TASK_DEFINITION_JSON: <<parameters.task_definition_json>>
         ORB_STR_PROFILE_NAME: <<parameters.profile_name>>
+        ORB_AWS_REGION: << parameters.region >>

--- a/src/commands/verify_revision_is_deployed.yml
+++ b/src/commands/verify_revision_is_deployed.yml
@@ -34,6 +34,10 @@ parameters:
     description: AWS profile name to be configured.
     type: string
     default: "default"
+  region:
+    description: AWS region to use. Defaults to AWS_DEFAULT_REGION environment variable.
+    type: string
+    default: $AWS_DEFAULT_REGION
 steps:
   - run:
       name: Verify that the revision is deployed and older revisions are stopped
@@ -46,6 +50,7 @@ steps:
         ORB_STR_TASK_DEF_ARN: <<parameters.task_definition_arn>>
         ORB_VAL_MAX_POLL_ATTEMPTS: <<parameters.max_poll_attempts>>
         ORB_STR_CLUSTER_NAME: <<parameters.cluster>>
+        ORB_AWS_REGION: << parameters.region >>
         ORB_VAL_POLL_INTERVAL: <<parameters.poll_interval>>
         ORB_VAL_FAIL_ON_VERIFY_TIMEOUT: <<parameters.fail_on_verification_timeout>>
         ORB_STR_PROFILE_NAME: <<parameters.profile_name>>

--- a/src/examples/deploy_ecs_scheduled_task.yml
+++ b/src/examples/deploy_ecs_scheduled_task.yml
@@ -4,8 +4,8 @@ description: |
 usage:
   version: 2.1
   orbs:
-    aws-cli: circleci/aws-cli@4.0
-    aws-ecs: circleci/aws-ecs@4.0
+    aws-cli: circleci/aws-cli@5.1.0
+    aws-ecs: circleci/aws-ecs@6.0.0
   jobs:
     deploy_scheduled_task:
       docker:
@@ -14,14 +14,16 @@ usage:
         - aws-cli/setup:
             # This example uses CircleCI's OpenID Connect Token to generate temporary AWS keys
             role_arn: "arn:aws:iam::123456789012:role/OIDC_ARN"
-            region: AWS_REGION
+            region: us-east-1
             profile_name: "OIDC-PROFILE"
             session_duration: "3600"
             role_session_name: "example-session-name"
         - aws-ecs/update_task_definition_from_json:
             task_definition_json: my-app-definition.json
+            region: us-east-1
         - aws-ecs/deploy_ecs_scheduled_task:
             rule_name: "example-rule"
+            region: us-east-1
   workflows:
     deploy:
       jobs:

--- a/src/examples/deploy_service_update.yml
+++ b/src/examples/deploy_service_update.yml
@@ -4,10 +4,10 @@ description: |
 usage:
   version: 2.1
   orbs:
-    aws-ecr: circleci/aws-ecr@9.0
-    aws-ecs: circleci/aws-ecs@4.0
+    aws-ecr: circleci/aws-ecr@9.3.4
+    aws-ecs: circleci/aws-ecs@6.0.0
     # Importing aws-cli orb is required for authentication
-    aws-cli: circleci/aws-cli@4.0
+    aws-cli: circleci/aws-cli@5.1.0
   workflows:
     build-and-deploy:
       jobs:
@@ -31,6 +31,7 @@ usage:
                   role_arn: "arn:aws:iam::123456789012:role/VALID_OIDC_ECS_ROLE"
             # Must use same profile configured in aws-cli/setup command
             profile: "OIDC-USER"
+            region: us-east-1
             requires:
               - aws-ecr/build-and-push-image
             family: '${MY_APP_PREFIX}-service'

--- a/src/examples/run_task_ec2.yml
+++ b/src/examples/run_task_ec2.yml
@@ -2,8 +2,8 @@ description: Start the run of an ECS task on EC2.
 usage:
   version: 2.1
   orbs:
-    aws-ecs: circleci/aws-ecs@4.0
-    aws-cli: circleci/aws-cli@4.0
+    aws-ecs: circleci/aws-ecs@6.0.0
+    aws-cli: circleci/aws-cli@5.1.0
   jobs:
     run_task:
       docker:
@@ -15,6 +15,7 @@ usage:
         - aws-ecs/run_task:
             cluster: cluster1
             task_definition: myapp
+            region: us-east-1
             awsvpc: false
             launch_type: EC2
   workflows:

--- a/src/examples/run_task_fargate.yml
+++ b/src/examples/run_task_fargate.yml
@@ -2,7 +2,7 @@ description: Start the run of an ECS task on Fargate.
 usage:
   version: 2.1
   orbs:
-    aws-ecs: circleci/aws-ecs@4.0
+    aws-ecs: circleci/aws-ecs@6.0.0
   jobs:
     run_task:
       docker:
@@ -13,6 +13,7 @@ usage:
             role_arn: "arn:aws:iam::123456789012:role/VALID_OIDC_ECS_ROLE"
         - aws-ecs/run_task:
             cluster: cluster1
+            region: us-east-1
             task_definition: myapp
             subnet_ids: '$SUBNET_ONE, $SUBNET_TWO'
             security_group_ids: $SECURITY_GROUP_IDS

--- a/src/examples/run_task_fargate_spot.yml
+++ b/src/examples/run_task_fargate_spot.yml
@@ -5,7 +5,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    aws-ecs: circleci/aws-ecs@4.0
+    aws-ecs: circleci/aws-ecs@6.0.0
   jobs:
     run_task:
       docker:
@@ -18,6 +18,7 @@ usage:
             cluster: $CLUSTER_NAME
             capacity_provider_strategy: capacityProvider=FARGATE,weight=1 capacityProvider=FARGATE_SPOT,weight=1
             launch_type: ""
+            region: us-east-1
             task_definition: $My_Task_Def
             subnet_ids: '$SUBNET_ONE, $SUBNET_TWO'
             security_group_ids: $SECURITY_GROUP_IDS_FETCHED

--- a/src/examples/update_service.yml
+++ b/src/examples/update_service.yml
@@ -4,8 +4,8 @@ description: |
 usage:
   version: 2.1
   orbs:
-    aws-cli: circleci/aws-cli@4.0
-    aws-ecs: circleci/aws-ecs@4.0
+    aws-cli: circleci/aws-cli@5.1.0
+    aws-ecs: circleci/aws-ecs@6.0.0
   jobs:
     update-tag:
       docker:
@@ -21,6 +21,7 @@ usage:
         - aws-ecs/update_service:
             family: '${MY_APP_PREFIX}-service'
             cluster: '${MY_APP_PREFIX}-cluster'
+            region: us-east-1
             container_image_name_updates: 'container=${MY_APP_PREFIX}-service,tag=stable'
   workflows:
     deploy:

--- a/src/examples/update_task_definition_from_json.yml
+++ b/src/examples/update_task_definition_from_json.yml
@@ -2,8 +2,8 @@ description: Use the AWS CLI and this orb to create a new ECS task definition ba
 usage:
   version: 2.1
   orbs:
-    aws-cli: circleci/aws-cli@4.0
-    aws-ecs: circleci/aws-ecs@4.0
+    aws-cli: circleci/aws-cli@5.1.0
+    aws-ecs: circleci/aws-ecs@6.0.0
   jobs:
     update-tag:
       docker:
@@ -17,6 +17,7 @@ usage:
             session_duration: "3600"
             role_session_name: "example-session-name"
         - aws-ecs/update_task_definition_from_json:
+            region: us-east-1
             task_definition_json: my-app-definition.json
   workflows:
     deploy:

--- a/src/examples/verify_revision_deployment.yml
+++ b/src/examples/verify_revision_deployment.yml
@@ -2,8 +2,8 @@ description: Verify the deployment of an ECS revision.
 usage:
   version: 2.1
   orbs:
-    aws-cli: circleci/aws-cli@4.0
-    aws-ecs: circleci/aws-ecs@4.0
+    aws-cli: circleci/aws-cli@5.1.0
+    aws-ecs: circleci/aws-ecs@6.0.0
   jobs:
     verify-deployment:
       docker:
@@ -30,6 +30,7 @@ usage:
         - aws-ecs/verify_revision_is_deployed:
             family: '${MY_APP_PREFIX}-service'
             cluster: '${MY_APP_PREFIX}-cluster'
+            region: us-east-1
             task_definition_arn: '${TASK_DEFINITION_ARN}'
   workflows:
     test-workflow:

--- a/src/jobs/deploy_service_update.yml
+++ b/src/jobs/deploy_service_update.yml
@@ -3,7 +3,7 @@ description: >
 
 parameters:
   region:
-    description: AWS region to operate in. Set this to the name of the environment variable you will use to hold this value, i.e. AWS_DEFAULT_REGION.
+    description: AWS region to use. Defaults to AWS_DEFAULT_REGION environment variable.
     type: string
     default: ${AWS_DEFAULT_REGION}
   profile_name:

--- a/src/jobs/run_task.yml
+++ b/src/jobs/run_task.yml
@@ -153,6 +153,10 @@ parameters:
     description: The executor to use for this job. By default, this will use the "default" executor provided by this orb.
     type: executor
     default: default
+  region:
+    description: AWS region to use. Defaults to AWS_DEFAULT_REGION environment variable.
+    type: string
+    default: $AWS_DEFAULT_REGION
 executor: << parameters.executor >>
 steps:
   - steps: << parameters.auth >>
@@ -167,6 +171,7 @@ steps:
       launch_type: << parameters.launch_type >>
       platform_version: << parameters.platform_version >>
       awsvpc: << parameters.awsvpc >>
+      region: << parameters.region >>
       subnet_ids: << parameters.subnet_ids >>
       security_group_ids: << parameters.security_group_ids >>
       assign_public_ip: << parameters.assign_public_ip >>

--- a/src/jobs/run_task.yml
+++ b/src/jobs/run_task.yml
@@ -153,10 +153,6 @@ parameters:
     description: The executor to use for this job. By default, this will use the "default" executor provided by this orb.
     type: executor
     default: default
-  region:
-    description: AWS region to use. Defaults to AWS_DEFAULT_REGION environment variable.
-    type: string
-    default: $AWS_DEFAULT_REGION
 executor: << parameters.executor >>
 steps:
   - steps: << parameters.auth >>

--- a/src/jobs/run_task.yml
+++ b/src/jobs/run_task.yml
@@ -3,7 +3,7 @@ description: |
 
 parameters:
   region:
-    description: AWS region to operate in. Set this to the name of the environment variable you will use to hold this value, i.e. AWS_DEFAULT_REGION.
+    description: AWS region to use. Defaults to AWS_DEFAULT_REGION environment variable.
     type: string
     default: ${AWS_DEFAULT_REGION}
   profile_name:

--- a/src/jobs/update_task_definition.yml
+++ b/src/jobs/update_task_definition.yml
@@ -98,6 +98,7 @@ steps:
       family: << parameters.family >>
       container_image_name_updates: << parameters.container_image_name_updates >>
       container_env_var_updates: << parameters.container_env_var_updates >>
+      region: << parameters.region >>
       container_secret_updates: << parameters.container_secret_updates >>
       container_docker_label_updates: << parameters.container_docker_label_updates >>
       profile_name: << parameters.profile_name >>
@@ -106,3 +107,4 @@ steps:
       steps:
         - deploy_ecs_scheduled_task:
             rule_name: <<parameters.rule_name>>
+            region: << parameters.region >>

--- a/src/jobs/update_task_definition.yml
+++ b/src/jobs/update_task_definition.yml
@@ -3,7 +3,7 @@ description: |
 
 parameters:
   region:
-    description: AWS region to operate in. Set this to the name of the environment variable you will use to hold this value, i.e. AWS_DEFAULT_REGION.
+    description: AWS region to use. Defaults to AWS_DEFAULT_REGION environment variable.
     type: string
     default: ${AWS_DEFAULT_REGION}
   profile_name:

--- a/src/jobs/update_task_definition_from_json.yml
+++ b/src/jobs/update_task_definition_from_json.yml
@@ -30,10 +30,6 @@ parameters:
     description: The executor to use for this job. By default, this will use the "default" executor provided by this orb.
     type: executor
     default: default
-  region:
-    description: AWS region to use. Defaults to AWS_DEFAULT_REGION environment variable.
-    type: string
-    default: $AWS_DEFAULT_REGION
 executor: << parameters.executor >>
 steps:
   - steps: << parameters.auth >>

--- a/src/jobs/update_task_definition_from_json.yml
+++ b/src/jobs/update_task_definition_from_json.yml
@@ -2,7 +2,7 @@ description: |
   Install AWS CLI and  a task definition from a json file.
 parameters:
   region:
-    description: AWS region to operate in. Set this to the name of the environment variable you will use to hold this value, i.e. AWS_DEFAULT_REGION.
+    description: AWS region to use. Defaults to AWS_DEFAULT_REGION environment variable.
     type: string
     default: ${AWS_DEFAULT_REGION}
   profile_name:

--- a/src/jobs/update_task_definition_from_json.yml
+++ b/src/jobs/update_task_definition_from_json.yml
@@ -30,14 +30,20 @@ parameters:
     description: The executor to use for this job. By default, this will use the "default" executor provided by this orb.
     type: executor
     default: default
+  region:
+    description: AWS region to use. Defaults to AWS_DEFAULT_REGION environment variable.
+    type: string
+    default: $AWS_DEFAULT_REGION
 executor: << parameters.executor >>
 steps:
   - steps: << parameters.auth >>
   - update_task_definition_from_json:
       task_definition_json: << parameters.task_definition_json >>
       profile_name: << parameters.profile_name >>
+      region: << parameters.region >>
   - when:
       condition: <<parameters.deploy_scheduled_task>>
       steps:
         - deploy_ecs_scheduled_task:
             rule_name: <<parameters.rule_name>>
+            region: << parameters.region >>

--- a/src/scripts/deploy_ecs_scheduled_task.sh
+++ b/src/scripts/deploy_ecs_scheduled_task.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 td_arn=$CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN
-
+ORB_AWS_REGION="$(circleci env subst "$ORB_AWS_REGION")"
 if [ -z "$td_arn" ]; then
     echo "Updated task definition not found. Please run update-task-definition command before deploy-ecs-scheduled-task"
     exit 1
@@ -16,7 +16,7 @@ fi
 CLI_OUTPUT_FILE=$(mktemp cli-output.json.XXXX)
 CLI_INPUT_FILE=$(mktemp cli-input.json.XXXX)
 
-aws events list-targets-by-rule --rule "$ORB_STR_RULE_NAME" --output json > "$CLI_OUTPUT_FILE"
+aws events list-targets-by-rule --rule "$ORB_STR_RULE_NAME" --output json --region "$ORB_AWS_REGION" > "$CLI_OUTPUT_FILE"
 
 if < "$CLI_OUTPUT_FILE" jq ' .Targets[] | has("EcsParameters")' | grep "false"; then
     echo "Invalid ECS Rule. $ORB_STR_RULE_NAME does not contain EcsParameters key. Please create a valid ECS Rule and try again"
@@ -24,4 +24,4 @@ if < "$CLI_OUTPUT_FILE" jq ' .Targets[] | has("EcsParameters")' | grep "false"; 
 fi
 
 < "$CLI_OUTPUT_FILE" jq --arg td_arn "$td_arn" '.Targets[].EcsParameters.TaskDefinitionArn |= $td_arn' > "$CLI_INPUT_FILE"
-aws events put-targets --rule "$ORB_STR_RULE_NAME" --cli-input-json "$(cat "$CLI_INPUT_FILE")"
+aws events put-targets --rule "$ORB_STR_RULE_NAME" --cli-input-json "$(cat "$CLI_INPUT_FILE")" --region "$ORB_AWS_REGION"

--- a/src/scripts/get_prev_task.sh
+++ b/src/scripts/get_prev_task.sh
@@ -9,6 +9,7 @@ ORB_STR_PROFILE_NAME="$(circleci env subst "$ORB_STR_PROFILE_NAME")"
 ORB_STR_CONTAINER_SECRET_UPDATES="$(circleci env subst "$ORB_STR_CONTAINER_SECRET_UPDATES")"
 ORB_STR_CONTAINER_DOCKER_LABEL_UPDATES="$(circleci env subst "$ORB_STR_CONTAINER_DOCKER_LABEL_UPDATES")"
 ORB_STR_PREVIOUS_REVISION_NUMBER="$(circleci env subst "$ORB_STR_PREVIOUS_REVISION_NUMBER")"
+ORB_AWS_REGION="$(circleci env subst "$ORB_AWS_REGION")"
 
 if [ -z "${ECS_PARAM_PREVIOUS_REVISION}" ]; then
   ECS_TASK_DEFINITION_NAME="$ORB_STR_FAMILY"
@@ -17,7 +18,7 @@ else
 fi
 
 # shellcheck disable=SC2034
-PREVIOUS_TASK_DEFINITION="$(aws ecs describe-task-definition --task-definition "${ECS_TASK_DEFINITION_NAME}" --include TAGS --profile "${ORB_STR_PROFILE_NAME}" --region "${AWS_DEFAULT_REGION}" "$@")"
+PREVIOUS_TASK_DEFINITION="$(aws ecs describe-task-definition --task-definition "${ECS_TASK_DEFINITION_NAME}" --include TAGS --profile "${ORB_STR_PROFILE_NAME}" --region "${ORB_AWS_REGION}" "$@")"
 
 # Prepare script for updating container definitions
 

--- a/src/scripts/register_new_task_def.sh
+++ b/src/scripts/register_new_task_def.sh
@@ -4,6 +4,7 @@ set -o noglob
 # These variables are evaluated so the config file may contain and pass in environment variables to the parameters.
 ORB_STR_FAMILY="$(circleci env subst "$ORB_STR_FAMILY")"
 ORB_STR_PROFILE_NAME="$(circleci env subst "$ORB_STR_PROFILE_NAME")"
+ORB_AWS_REGION="$(circleci env subst "$ORB_AWS_REGION")"
 
 if [ -n "${CCI_ORB_AWS_ECS_TASK_ROLE}" ]; then
     set -- "$@" --task-role-arn "${CCI_ORB_AWS_ECS_TASK_ROLE}"
@@ -69,6 +70,7 @@ REVISION=$(aws ecs register-task-definition \
     --profile "${ORB_STR_PROFILE_NAME}" \
     "$@" \
     --output text \
+    --region "${ORB_AWS_REGION}" \
     --query 'taskDefinition.taskDefinitionArn')
 echo "Registered task definition: ${REVISION}"
 

--- a/src/scripts/run_task.sh
+++ b/src/scripts/run_task.sh
@@ -13,6 +13,7 @@ ORB_STR_CD_CAPACITY_PROVIDER_STRATEGY="$(circleci env subst "$ORB_STR_CD_CAPACIT
 ORB_STR_RUN_TASK_OUTPUT="$(circleci env subst "$ORB_STR_RUN_TASK_OUTPUT")"
 ORB_STR_PROFILE_NAME="$(circleci env subst "$ORB_STR_PROFILE_NAME")"
 ORB_STR_ASSIGN_PUB_IP="$(circleci env subst "$ORB_STR_ASSIGN_PUB_IP")"
+ORB_AWS_REGION="$(circleci env subst "$ORB_AWS_REGION")"
 
 if [[ "$ORB_STR_OVERRIDES" == *"\${"* ]]; then
     ORB_STR_OVERRIDES="$(echo "${ORB_STR_OVERRIDES}" | circleci env subst)"
@@ -99,10 +100,10 @@ set -- "$@" --cluster "$ORB_STR_CLUSTER_NAME"
 
 if [ -n "${ORB_STR_RUN_TASK_OUTPUT}" ]; then
     set -x
-    aws ecs run-task --profile "${ORB_STR_PROFILE_NAME}" "$@" | tee "${ORB_STR_RUN_TASK_OUTPUT}"
+    aws ecs run-task --profile "${ORB_STR_PROFILE_NAME}" --region "${ORB_AWS_REGION}" "$@" | tee "${ORB_STR_RUN_TASK_OUTPUT}"
     set +x
 else
     set -x    
-    aws ecs run-task --profile "${ORB_STR_PROFILE_NAME}" "$@"
+    aws ecs run-task --profile "${ORB_STR_PROFILE_NAME}" --region "${ORB_AWS_REGION}" "$@"
     set +x
 fi

--- a/src/scripts/update_service_via_task_def.sh
+++ b/src/scripts/update_service_via_task_def.sh
@@ -6,6 +6,7 @@ ORB_STR_FAMILY="$(circleci env subst "$ORB_STR_FAMILY")"
 ORB_STR_CLUSTER_NAME="$(circleci env subst "$ORB_STR_CLUSTER_NAME")"
 ORB_STR_SERVICE_NAME="$(circleci env subst "$ORB_STR_SERVICE_NAME")"
 ORB_STR_PROFILE_NAME="$(circleci env subst "$ORB_STR_PROFILE_NAME")"
+ORB_AWS_REGION="$(circleci env subst "$ORB_AWS_REGION")"
 
 if [ -z "${ORB_STR_SERVICE_NAME}" ]; then
     ORB_STR_SERVICE_NAME="$ORB_STR_FAMILY"
@@ -25,6 +26,7 @@ DEPLOYED_REVISION=$(aws ecs update-service \
     --service "${ORB_STR_SERVICE_NAME}" \
     --task-definition "${CCI_ORB_AWS_ECS_REGISTERED_TASK_DFN}" \
     --output text \
+    --region "${ORB_AWS_REGION}" \
     --query service.taskDefinition \
     "$@")
 echo "export CCI_ORB_AWS_ECS_DEPLOYED_REVISION='${DEPLOYED_REVISION}'" >> "$BASH_ENV"

--- a/src/scripts/update_task_definition_from_json.sh
+++ b/src/scripts/update_task_definition_from_json.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 ORB_STR_PROFILE_NAME="$(circleci env subst "$ORB_STR_PROFILE_NAME")"
 ORB_STR_TASK_DEFINITION_JSON="$(circleci env subst "$ORB_STR_TASK_DEFINITION_JSON")"
+ORB_AWS_REGION="$(circleci env subst "$ORB_AWS_REGION")"
 
 if [ "${ORB_STR_TASK_DEFINITION_JSON:0:1}" != "/" ]; then
     ORB_STR_TASK_DEFINITION_JSON="$(pwd)/${ORB_STR_TASK_DEFINITION_JSON}"
@@ -10,6 +11,7 @@ REVISION=$(aws ecs register-task-definition \
     --profile "${ORB_STR_PROFILE_NAME}" \
     --cli-input-json file://"${ORB_STR_TASK_DEFINITION_JSON}" \
     --output text \
+    --region "${ORB_AWS_REGION}" \
     --query 'taskDefinition.taskDefinitionArn' \
     "$@")
 echo "Registered task definition: ${REVISION}"

--- a/src/scripts/verify_revision_is_deployed.sh
+++ b/src/scripts/verify_revision_is_deployed.sh
@@ -5,6 +5,7 @@ ORB_STR_SERVICE_NAME="$(circleci env subst "$ORB_STR_SERVICE_NAME")"
 ORB_STR_CLUSTER_NAME="$(circleci env subst "$ORB_STR_CLUSTER_NAME")"
 ORB_STR_TASK_DEF_ARN="$(circleci env subst "$ORB_STR_TASK_DEF_ARN")"
 ORB_STR_PROFILE_NAME="$(circleci env subst "$ORB_STR_PROFILE_NAME")"
+ORB_AWS_REGION="$(circleci env subst "$ORB_AWS_REGION")"
 
 if [ "$ORB_STR_TASK_DEF_ARN" = "" ]; then
     echo "Invalid task-definition-arn parameter value: $ORB_STR_TASK_DEF_ARN"
@@ -27,7 +28,7 @@ do
         --profile "${ORB_STR_PROFILE_NAME}" \
         --cluster "$ORB_STR_CLUSTER_NAME" \
         --services "${ORB_STR_SERVICE_NAME}" \
-        --region "${AWS_DEFAULT_REGION}" \
+        --region "${ORB_AWS_REGION}" \
         --output text \
         --query 'services[0].deployments[].[taskDefinition, status]' \
         "$@")
@@ -35,7 +36,7 @@ do
         --profile "${ORB_STR_PROFILE_NAME}" \
         --cluster "$ORB_STR_CLUSTER_NAME" \
         --services "${ORB_STR_SERVICE_NAME}" \
-        --region "${AWS_DEFAULT_REGION}" \
+        --region "${ORB_AWS_REGION}" \
         --output text \
         --query 'length(services[0].deployments)' \
         "$@")
@@ -43,7 +44,7 @@ do
         --profile "${ORB_STR_PROFILE_NAME}" \
         --cluster "$ORB_STR_CLUSTER_NAME" \
         --services "${ORB_STR_SERVICE_NAME}" \
-        --region "${AWS_DEFAULT_REGION}" \
+        --region "${ORB_AWS_REGION}" \
         --output text \
         --query "services[0].deployments[?taskDefinition==\`$ORB_STR_TASK_DEF_ARN\` && runningCount == desiredCount && (status == \`PRIMARY\` || status == \`ACTIVE\`)][taskDefinition]" \
         "$@")


### PR DESCRIPTION
This changes the way region is passed to to all jobs and commands in the orb. This used to be done using the environment variable values.
The new parameter is set to used the AWS_DEFAULT_REGION env as a default when it is not set, this env was used for some other commands already.
The change should be a major version as some of the commands are just using the default region defined in the profile or the defaults environment variables, and this won't work now as the region is always explicitly set.
Also the way to pass the value is standardised to pass the value instead of the name of an environment variable. Anyway, an environment variable can be passed, but using the $ notation instead of just the name.