### PR TITLE
export ORB_STR_TASK_ARN as part of $BASH_ENV

### DIFF
--- a/src/scripts/run_task.sh
+++ b/src/scripts/run_task.sh
@@ -115,7 +115,7 @@ else
     set +x
 fi
 
-echo 'export ORB_STR_TASK_ARN=$ORB_STR_TASK_ARN' >> $BASH_ENV
+echo "export ORB_STR_TASK_ARN='$ORB_STR_TASK_ARN'" >> "$BASH_ENV"
 
 if [ "$ORB_BOOL_WAIT_TASK_STOPPED" == "1" ]; then
     if [ -z "${ORB_STR_TASK_ARN}" ]; then

--- a/src/scripts/run_task.sh
+++ b/src/scripts/run_task.sh
@@ -115,6 +115,8 @@ else
     set +x
 fi
 
+echo 'export ORB_STR_TASK_ARN=$ORB_STR_TASK_ARN' >> $BASH_ENV
+
 if [ "$ORB_BOOL_WAIT_TASK_STOPPED" == "1" ]; then
     if [ -z "${ORB_STR_TASK_ARN}" ]; then
         exit 1


### PR DESCRIPTION
This PR exports the taskArn to bash in case you want to do something after the task ended.
For example: check the logs for errors.