### PR TITLE
Allow adding free text to command names

### DIFF
--- a/src/commands/deploy_ecs_scheduled_task.yml
+++ b/src/commands/deploy_ecs_scheduled_task.yml
@@ -9,9 +9,13 @@ parameters:
     description: AWS region to use. Defaults to AWS_DEFAULT_REGION environment variable.
     type: string
     default: $AWS_DEFAULT_REGION
+  extra_command_label:
+    description: Extra label that attaches to the end of every step name
+    type: string
+    default: ""
 steps:
   - run:
-      name: Deploy rule with updated task definition
+      name: Deploy rule with updated task definition <<parameters.extra_command_label>>
       environment:
         ORB_STR_RULE_NAME: <<parameters.rule_name>>
         ORB_AWS_REGION: << parameters.region >>

--- a/src/commands/install_ecs_cli.yml
+++ b/src/commands/install_ecs_cli.yml
@@ -15,10 +15,14 @@ parameters:
     description: |
       By default, if the AWS ECS CLI is detected on the system, the install will be skipped.
       Enable this to override the installed version and install your specified version.
+  extra_command_label:
+    description: Extra label that attaches to the end of every step name
+    type: string
+    default: ""
 
 steps:
   - run:
-      name: Install AWS ECS CLI
+      name: Install AWS ECS CLI <<parameters.extra_command_label>>
       environment:
         ORB_STR_VERSION: <<parameters.version>>
         ORB_EVAL_INSTALL_DIR: <<parameters.install_dir>>

--- a/src/commands/run_task.yml
+++ b/src/commands/run_task.yml
@@ -142,9 +142,13 @@ parameters:
       Elapsed time the command can run without output. The string is a decimal with unit suffix, such as "20m", "1.25h", "5s".
       The default is 10 minutes.
     default: "10m"
+  extra_command_label:
+    description: Extra label that attaches to the end of every step name
+    type: string
+    default: ""
 steps:
   - run:
-      name: Run Task
+      name: Run Task <<parameters.extra_command_label>>
       no_output_timeout: <<parameters.no_output_timeout>>
       command: <<include(scripts/run_task.sh)>>
       environment:

--- a/src/commands/update_service.yml
+++ b/src/commands/update_service.yml
@@ -252,12 +252,17 @@ parameters:
       Default to empty.
     default: ""
     type: string
+  extra_command_label:
+    description: Extra label that attaches to the end of every step name
+    type: string
+    default: ""
 
 steps:
   - unless:
       condition: << parameters.skip_task_definition_registration >>
       steps:
         - update_task_definition:
+            extra_command_label: <<parameters.extra_command_label>>
             family: << parameters.family >>
             container_image_name_updates: << parameters.container_image_name_updates >>
             container_env_var_updates: << parameters.container_env_var_updates >>
@@ -270,7 +275,7 @@ steps:
       condition: << parameters.skip_task_definition_registration >>
       steps:
         - run:
-            name: Retrieve previous task definition
+            name: Retrieve previous task definition <<parameters.extra_command_label>>
             command: |
               TASK_DEFINITION_ARN=$(aws ecs describe-task-definition \
                 --task-definition << parameters.family >> \
@@ -283,7 +288,7 @@ steps:
       condition: << parameters.task_definition_tags >>
       steps:
         - run:
-            name: Update task definition with additional tags
+            name: Update task definition with additional tags <<parameters.extra_command_label>>
             command: <<include(scripts/update_task_definition_tags.sh>>
             environment:
               ORB_STR_TASK_DEFINITION_TAGS: << parameters.task_definition_tags >>
@@ -296,7 +301,7 @@ steps:
           - << parameters.deployment_controller >>
       steps:
         - run:
-            name: Update ECS Blue/Green service with registered task definition.
+            name: Update ECS Blue/Green service with registered task definition. <<parameters.extra_command_label>>
             command: <<include(scripts/update_bluegreen_service_via_task_def.sh)>>
             no_output_timeout: << parameters.verification_timeout >>
             environment:
@@ -321,7 +326,7 @@ steps:
           - << parameters.deployment_controller >>
       steps:
         - run:
-            name: Update service with registered task definition
+            name: Update service with registered task definition <<parameters.extra_command_label>>
             command: <<include(scripts/update_service_via_task_def.sh)>>
             environment:
               ORB_STR_SERVICE_NAME: <<parameters.service_name>>
@@ -349,6 +354,7 @@ steps:
               - << parameters.deployment_controller >>
       steps:
         - verify_revision_is_deployed:
+            extra_command_label: <<parameters.extra_command_label>>
             family: << parameters.family >>
             cluster: << parameters.cluster >>
             service_name: << parameters.service_name >>

--- a/src/commands/update_task_definition.yml
+++ b/src/commands/update_task_definition.yml
@@ -84,9 +84,13 @@ parameters:
     description: AWS region to use. Defaults to AWS_DEFAULT_REGION environment variable.
     type: string
     default: $AWS_DEFAULT_REGION
+  extra_command_label:
+    description: Extra label that attaches to the end of every step name
+    type: string
+    default: ""
 steps:
   - run:
-      name: Retrieve previous task definition and prepare new task definition values
+      name: Retrieve previous task definition and prepare new task definition values <<parameters.extra_command_label>>
       command: <<include(scripts/get_prev_task.sh)>>
       environment:
         ORB_STR_FAMILY: <<parameters.family>>
@@ -100,7 +104,7 @@ steps:
         ORB_STR_CONTAINER_SECRET_UPDATES: <<parameters.container_secret_updates>>
         ORB_STR_CONTAINER_DOCKER_LABEL_UPDATES: << parameters.container_docker_label_updates >>
   - run:
-      name: Register new task definition
+      name: Register new task definition <<parameters.extra_command_label>>
       command: <<include(scripts/register_new_task_def.sh)>>
       environment:
         ORB_STR_FAMILY: <<parameters.family>>
@@ -110,7 +114,7 @@ steps:
       condition: << parameters.task_definition_tags >>
       steps:
         - run:
-            name: Update task definition with additional tags
+            name: Update task definition with additional tags <<parameters.extra_command_label>>
             command: <<include(scripts/update_task_definition_tags.sh>>
             environment:
               ORB_STR_TASK_DEFINITION_TAGS: << parameters.task_definition_tags >>

--- a/src/commands/update_task_definition_from_json.yml
+++ b/src/commands/update_task_definition_from_json.yml
@@ -12,9 +12,14 @@ parameters:
     description: AWS region to use. Defaults to AWS_DEFAULT_REGION environment variable.
     type: string
     default: $AWS_DEFAULT_REGION
+  extra_command_label:
+    description: Extra label that attaches to the end of every step name
+    type: string
+    default: ""
+
 steps:
   - run:
-      name: Register new task definition
+      name: Register new task definition <<parameters.extra_command_label>>
       command: <<include(scripts/update_task_definition_from_json.sh)>>
       environment:
         ORB_STR_TASK_DEFINITION_JSON: <<parameters.task_definition_json>>

--- a/src/commands/verify_revision_is_deployed.yml
+++ b/src/commands/verify_revision_is_deployed.yml
@@ -38,9 +38,13 @@ parameters:
     description: AWS region to use. Defaults to AWS_DEFAULT_REGION environment variable.
     type: string
     default: $AWS_DEFAULT_REGION
+  extra_command_label:
+    description: Extra label that attaches to the end of every step name
+    type: string
+    default: ""
 steps:
   - run:
-      name: Verify that the revision is deployed and older revisions are stopped
+      name: Verify that the revision is deployed and older revisions are stopped <<parameters.extra_command_label>>
       description: |
         Poll the deployment status at intervals till the given task definition revision has reached its desired running task count and is the only one deployed for the service.
       command: <<include(scripts/verify_revision_is_deployed.sh)>>


### PR DESCRIPTION
In CircleCI, when running a job from a 3rd party orb, there is a built in functionality to overwrite the job name (by passing `name:` parameter). This is helpful to indicate what exactly the job doing (for example instead of `aws-ecs/run_task` one can specify `Run service_xx database migrations in prod cluster`). However, there is no such built in functionality for orb commands, and it needs to be implemeted explicitly.

This PR introduces a new command parameter `extra_command_label` which is a string that attaches to all the default command names, which can be used to distinguish the commands that are running in CircleCI dashboard. By default this parameter is an empty string, so it doesn't change default behaviour.

Use case I am trying to improve: when deploying an app, we actually need to update 3 different ECS services, and it is impossible to understand which ECS service is being deployed without expanding command in UI and looking for a service name. Attaching `extra_command_label: service_xx` to a command would greatly improve readability.