### PR TITLE
Bump Python version to 3.13

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -16,7 +16,7 @@ release-filters: &release-filters
 jobs:
   pytest:
     docker:
-      - image: cimg/python:3.10.4
+      - image: cimg/python:3.13
     steps:
       - checkout
       - restore_cache:
@@ -194,7 +194,7 @@ jobs:
             set +x
   test-service-create:
     docker:
-      - image: cimg/python:3.10.4
+      - image: cimg/python:3.13
     shell: bash -eox pipefail
     steps:
       - checkout
@@ -225,7 +225,7 @@ jobs:
           aws ecs delete-service --cluster ecs-orb-ec2-1-cluster --service test-create --region us-west-2 --profile profile-create --force
   test-service-update:
     docker:
-      - image: cimg/python:3.10.4
+      - image: cimg/python:3.13
     parameters:
       aws-resource-name-prefix:
         description: "Prefix that the AWS resources for this launch type share"
@@ -301,7 +301,7 @@ jobs:
                 cluster: "<< parameters.aws-resource-name-prefix >>-cluster"
   test-task_definition-update:
     docker:
-      - image: cimg/python:3.10.4
+      - image: cimg/python:3.13
     parameters:
       family_name:
         description: "Family name"
@@ -332,7 +332,7 @@ jobs:
             aws ecs describe-task-definition --task-definition << parameters.family_name >> --include TAGS | grep "3072"
   set-up-run_task-test:
     docker:
-      - image: cimg/python:3.10.4
+      - image: cimg/python:3.13
     parameters:
       family_name:
         description: "Family name"
@@ -358,7 +358,7 @@ jobs:
               --container-definitions "[{\"name\":\"sleep\",\"image\":\"busybox\",\"command\":[\"sleep\",\"360\"],\"memory\":256,\"essential\":true}]"
   tear-down-run_task-test:
     docker:
-      - image: cimg/python:3.10.4
+      - image: cimg/python:3.13
     parameters:
       family_name:
         description: "Family name"

--- a/src/examples/deploy_ecs_scheduled_task.yml
+++ b/src/examples/deploy_ecs_scheduled_task.yml
@@ -9,7 +9,7 @@ usage:
   jobs:
     deploy_scheduled_task:
       docker:
-        - image: cimg/python:3.10
+        - image: cimg/python:3.13
       steps:
         - aws-cli/setup:
             # This example uses CircleCI's OpenID Connect Token to generate temporary AWS keys

--- a/src/examples/run_task_and_wait.yml
+++ b/src/examples/run_task_and_wait.yml
@@ -7,7 +7,7 @@ usage:
   jobs:
     run_task:
       docker:
-        - image: cimg/python:3.10
+        - image: cimg/python:3.13
       steps:
         - aws-cli/setup:
             profile_name: "OIDC-USER"

--- a/src/examples/run_task_ec2.yml
+++ b/src/examples/run_task_ec2.yml
@@ -7,7 +7,7 @@ usage:
   jobs:
     run_task:
       docker:
-        - image: cimg/python:3.10
+        - image: cimg/python:3.13
       steps:
         - aws-cli/setup:
             profile_name: "OIDC-USER"

--- a/src/examples/run_task_fargate.yml
+++ b/src/examples/run_task_fargate.yml
@@ -7,7 +7,7 @@ usage:
   jobs:
     run_task:
       docker:
-        - image: cimg/python:3.10
+        - image: cimg/python:3.13
       steps:
         - aws-cli/setup:
             profile_name: "OIDC-USER"

--- a/src/examples/run_task_fargate_spot.yml
+++ b/src/examples/run_task_fargate_spot.yml
@@ -10,7 +10,7 @@ usage:
   jobs:
     run_task:
       docker:
-        - image: cimg/python:3.10
+        - image: cimg/python:3.13
       steps:
         - aws-cli/setup:
             profile_name: "OIDC-USER"

--- a/src/examples/update_service.yml
+++ b/src/examples/update_service.yml
@@ -9,7 +9,7 @@ usage:
   jobs:
     update-tag:
       docker:
-        - image: cimg/python:3.10
+        - image: cimg/python:3.13
       steps:
         - aws-cli/setup:
             # This example uses CircleCI's OpenID Connect Token to generate temporary AWS keys

--- a/src/examples/update_task_definition_from_json.yml
+++ b/src/examples/update_task_definition_from_json.yml
@@ -7,7 +7,7 @@ usage:
   jobs:
     update-tag:
       docker:
-        - image: cimg/python:3.10
+        - image: cimg/python:3.13
       steps:
         - aws-cli/setup:
             # This example uses CircleCI's OpenID Connect Token to generate temporary AWS keys

--- a/src/examples/verify_revision_deployment.yml
+++ b/src/examples/verify_revision_deployment.yml
@@ -7,7 +7,7 @@ usage:
   jobs:
     verify-deployment:
       docker:
-        - image: cimg/python:3.10
+        - image: cimg/python:3.13
       steps:
         - aws-cli/setup:
             # This example uses CircleCI's OpenID Connect Token to generate temporary AWS keys

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -5,7 +5,7 @@ parameters:
     description: >
       Select any of the available tags here: https://circleci.com/developer/images/image/cimg/python.
     type: string
-    default: "3.10.4"
+    default: "3.13"
   resource_class:
     description: Configure the executor resource class
     type: enum


### PR DESCRIPTION
## Breaking Changes

### Default executor upgraded to Python 3.13.
The default executor image has been updated from `cimg/python:3.10.4` to `cimg/python:3.13`.

### Who is affected
Users who rely on this orb without specifying a custom executor, and whose workflows depend on Python 3.10 behaviour or have pinned dependencies that are incompatible with Python 3.13.

### How to pin back to the previous Python version

All orb jobs expose an executor parameter that accepts a custom executor definition. Pass the `aws-ecs/default` executor with the `tag` parameter set to your desired Python version:

```yaml
orbs:
  aws-ecs: circleci/aws-ecs@x.x.x

workflows:
  deploy:
    jobs:
      - aws-ecs/deploy-service-update:
          executor:
            name: aws-ecs/default
            tag: "3.10.4"
          # ... other parameters
```

This works for any job provided by this orb. Replace `3.10.4` with any tag available on the [cimg/python image page](https://circleci.com/developer/images/image/cimg/python).