### PR TITLE
feat: add deploy markers integration to deploy_service_update and upd…

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -6,3 +6,6 @@ description: >
 display:
   home_url: "https://aws.amazon.com/ecs/"
   source_url: "https://github.com/CircleCI-Public/aws-ecs-orb"
+
+orbs:
+  deploys: circleci/deploys@1.0

--- a/src/examples/deploy_service_update_with_deploy_markers.yml
+++ b/src/examples/deploy_service_update_with_deploy_markers.yml
@@ -1,0 +1,54 @@
+description: >
+  Deploy an ECS service with CircleCI deploy markers.
+  Four modes are available via the deploy_markers_mode parameter:
+    OFF             - no deploy markers
+    LOG             - log a deployment event after the ECS deploy
+    PLAN            - create a planned marker before the ECS deploy; caller manages status updates
+    PLAN_AND_UPDATE - full lifecycle: plan → running → success/failed (default)
+
+usage:
+  version: 2.1
+
+  orbs:
+    aws-ecs: circleci/aws-ecs@6.0.0
+    aws-ecr: circleci/aws-ecr@9.3.4
+    aws-cli: circleci/aws-cli@5.1.0
+
+  workflows:
+    deploy:
+      jobs:
+        # LOG mode — log a deployment event after the ECS deploy completes
+        - aws-ecs/deploy_service_update:
+            name: deploy-log
+            family: my-app-service
+            cluster: my-app-cluster
+            deploy_markers_mode: LOG
+            deploy_markers_target_version: ${CIRCLE_SHA1:0:7}
+            container_image_name_updates: container=my-app-service,tag=${CIRCLE_SHA1}
+            auth:
+              - aws-cli/setup:
+                  role_arn: ${AWS_ROLE_ARN}
+
+        # PLAN mode — create a planned marker before deploy; status updates are left to the caller
+        - aws-ecs/deploy_service_update:
+            name: deploy-plan
+            family: my-app-service
+            cluster: my-app-cluster
+            deploy_markers_mode: PLAN
+            deploy_markers_target_version: ${CIRCLE_SHA1:0:7}
+            container_image_name_updates: container=my-app-service,tag=${CIRCLE_SHA1}
+            auth:
+              - aws-cli/setup:
+                  role_arn: ${AWS_ROLE_ARN}
+
+        # PLAN_AND_UPDATE mode — full lifecycle managed by the orb
+        - aws-ecs/deploy_service_update:
+            name: deploy-full
+            family: my-app-service
+            cluster: my-app-cluster
+            deploy_markers_mode: PLAN_AND_UPDATE
+            deploy_markers_target_version: ${CIRCLE_SHA1:0:7}
+            container_image_name_updates: container=my-app-service,tag=${CIRCLE_SHA1}
+            auth:
+              - aws-cli/setup:
+                  role_arn: ${AWS_ROLE_ARN}

--- a/src/jobs/deploy_service_update.yml
+++ b/src/jobs/deploy_service_update.yml
@@ -222,6 +222,28 @@ parameters:
       The authentication method used to access your AWS account. Import the aws-cli orb in your config and
       provide the aws-cli/setup command to authenticate with your preferred method. View examples for more information.
     type: steps
+  deploy_markers_mode:
+    description: >
+      Controls CircleCI deploy marker integration via the deploys orb.
+      OFF: no deploy markers are created.
+      LOG: logs a deployment event after the ECS deploy completes.
+      PLAN: creates a planned deployment marker before the ECS deploy; status updates are left to the caller.
+      PLAN_AND_UPDATE: full lifecycle — plan before deploy, mark as running, then set SUCCESS or FAILED after (default).
+    type: enum
+    enum: [OFF, LOG, PLAN, PLAN_AND_UPDATE]
+    default: PLAN_AND_UPDATE
+  deploy_markers_deploy_name:
+    description: >
+      Unique identifier for this deployment within the workflow. Used by PLAN and PLAN_AND_UPDATE modes.
+      Must be unique if planning multiple deployments in the same workflow.
+    type: string
+    default: "deploy"
+  deploy_markers_target_version:
+    description: >
+      Version identifier shown in the CircleCI Deploys UI.
+      Used by LOG, PLAN, and PLAN_AND_UPDATE modes. Defaults to the short commit SHA if not set.
+    type: string
+    default: ""
   executor:
     description: The executor to use for this job. By default, this will use the "default" executor provided by this orb.
     type: executor
@@ -290,6 +312,25 @@ parameters:
 executor: << parameters.executor >>
 steps:
   - steps: << parameters.auth >>
+  - when:
+      condition:
+        or:
+          - equal: [<< parameters.deploy_markers_mode >>, "PLAN"]
+          - equal: [<< parameters.deploy_markers_mode >>, "PLAN_AND_UPDATE"]
+      steps:
+        - deploys/plan:
+            deploy_name: << parameters.deploy_markers_deploy_name >>
+            component_name: << parameters.family >>
+            environment_name: << parameters.cluster >>
+            target_version: << parameters.deploy_markers_target_version >>
+  - when:
+      condition:
+        equal: [<< parameters.deploy_markers_mode >>, "PLAN_AND_UPDATE"]
+      steps:
+        - deploys/update_status:
+            deploy_name: << parameters.deploy_markers_deploy_name >>
+            status: RUNNING
+            when: always
   - update_service:
       family: << parameters.family >>
       cluster: << parameters.cluster >>
@@ -326,3 +367,23 @@ steps:
       target_group: <<parameters.target_group>>
       container_name: <<parameters.container_name>>
       container_port: <<parameters.container_port>>
+  - when:
+      condition:
+        equal: [<< parameters.deploy_markers_mode >>, "LOG"]
+      steps:
+        - deploys/log:
+            component_name: << parameters.family >>
+            environment_name: << parameters.cluster >>
+            target_version: << parameters.deploy_markers_target_version >>
+  - when:
+      condition:
+        equal: [<< parameters.deploy_markers_mode >>, "PLAN_AND_UPDATE"]
+      steps:
+        - deploys/update_status:
+            deploy_name: << parameters.deploy_markers_deploy_name >>
+            status: SUCCESS
+            when: on_success
+        - deploys/update_status:
+            deploy_name: << parameters.deploy_markers_deploy_name >>
+            status: FAILED
+            when: on_fail

--- a/src/jobs/update_task_definition.yml
+++ b/src/jobs/update_task_definition.yml
@@ -87,6 +87,27 @@ parameters:
       The authentication method used to access your AWS account. Import the aws-cli orb in your config and
       provide the aws-cli/setup command to authenticate with your preferred method. View examples for more information.
     type: steps
+  deploy_markers_mode:
+    description: >
+      Controls CircleCI deploy marker integration via the deploys orb.
+      OFF: no deploy markers are created (default).
+      LOG: logs a deployment event after the task definition is registered.
+      Only LOG is available for this job because task definition registration does not target a specific running environment.
+    type: enum
+    enum: [OFF, LOG]
+    default: OFF
+  deploy_markers_environment_name:
+    description: >
+      Environment name shown in the CircleCI Deploys UI.
+      Used by LOG mode. Defaults to empty if not set.
+    type: string
+    default: ""
+  deploy_markers_target_version:
+    description: >
+      Version identifier shown in the CircleCI Deploys UI.
+      Used by LOG mode. Defaults to the short commit SHA if not set.
+    type: string
+    default: ""
   executor:
     description: The executor to use for this job. By default, this will use the "default" executor provided by this orb.
     type: executor
@@ -108,3 +129,11 @@ steps:
         - deploy_ecs_scheduled_task:
             rule_name: <<parameters.rule_name>>
             region: << parameters.region >>
+  - when:
+      condition:
+        equal: [<< parameters.deploy_markers_mode >>, "LOG"]
+      steps:
+        - deploys/log:
+            component_name: << parameters.family >>
+            environment_name: << parameters.deploy_markers_environment_name >>
+            target_version: << parameters.deploy_markers_target_version >>


### PR DESCRIPTION
Adds a deploy_markers_mode parameter to deploy_service_update (OFF/LOG/PLAN/PLAN_AND_UPDATE) and update_task_definition (OFF/LOG only), wiring in the circleci/deploys orb for lifecycle tracking. All new parameters default so existing configs require no changes.